### PR TITLE
GRIDEDIT-227: fix some code smells by removing complexity 

### DIFF
--- a/src/FlipEdges.cpp
+++ b/src/FlipEdges.cpp
@@ -43,21 +43,9 @@ meshkernel::FlipEdges::FlipEdges(std::shared_ptr<Mesh> mesh,
                                                                m_triangulateFaces(triangulateFaces),
                                                                m_projectToLandBoundary(projectToLandBoundary)
 {
-    if (m_landBoundaries->GetNumNodes() <= 0)
-    {
-        m_projectToLandBoundary = false;
-    }
     if (m_projectToLandBoundary)
     {
-        try
-        {
-            m_landBoundaries->FindNearestMeshBoundary(LandBoundaries::ProjectToLandBoundaryOption::WholeMesh);
-        }
-        catch (const std::exception&)
-        {
-            // TODO: log exception: need to rethrow the exception
-            m_projectToLandBoundary = false;
-        }
+        m_landBoundaries->FindNearestMeshBoundary(LandBoundaries::ProjectToLandBoundaryOption::WholeMesh);
     }
 };
 

--- a/src/FlipEdges.cpp
+++ b/src/FlipEdges.cpp
@@ -348,7 +348,7 @@ int meshkernel::FlipEdges::ComputeTopologyFunctional(int edge,
     int nL = m_mesh->m_nodesNumEdges[nodeLeft] - OptimalNumberOfConnectedNodes(nodeLeft);
     int nR = m_mesh->m_nodesNumEdges[nodeRight] - OptimalNumberOfConnectedNodes(nodeRight);
 
-    if (m_projectToLandBoundary)
+    if (m_projectToLandBoundary && m_landBoundaries->GetNumNodes() > 0)
     {
         if (m_landBoundaries->m_meshNodesLandBoundarySegments[firstNode] >= 0 && m_landBoundaries->m_meshNodesLandBoundarySegments[secondNode] >= 0)
         {

--- a/src/LandBoundaries.cpp
+++ b/src/LandBoundaries.cpp
@@ -57,7 +57,7 @@ namespace meshkernel
     {
         if (m_nodes.empty())
         {
-            throw std::invalid_argument("LandBoundaries::Administrate: The land boundaries contain no nodes.");
+            return;
         }
 
         // do not consider the landboundary nodes outside the polygon

--- a/src/MeshRefinement.cpp
+++ b/src/MeshRefinement.cpp
@@ -134,8 +134,7 @@ void meshkernel::MeshRefinement::Refine(const Polygons& polygon,
                 edge = -edge;
             }
 
-            //TODO: implement SmoothEdgeRefinementMask
-            //SmoothEdgeRefinementMask();
+            //TODO: implement SmoothEdgeRefinementMask SmoothEdgeRefinementMask();
         }
         else
         {

--- a/src/OrthogonalizationAndSmoothing.cpp
+++ b/src/OrthogonalizationAndSmoothing.cpp
@@ -241,8 +241,7 @@ void meshkernel::OrthogonalizationAndSmoothing::InnerIteration()
     SnapMeshToOriginalMeshBoundary();
 
     // compute local coordinates
-    // TODO: Not implemented yet
-    // ComputeCoordinates();
+    // TODO: Not implemented yet ComputeCoordinates();
 
     // project on land boundary
     m_landBoundaries->SnapMeshToLandBoundaries();


### PR DESCRIPTION
In FlipEdges I removed throwing exceptions if no land boundary nodes are present. we should simply return