### PR TITLE
GRIDEDIT-357: Add mkernel_add_landboundary API call

### DIFF
--- a/include/MeshKernel/LandBoundaries.hpp
+++ b/include/MeshKernel/LandBoundaries.hpp
@@ -57,11 +57,13 @@ namespace meshkernel
             WholeMesh = 4
         };
 
-        /// @brief Default Ctor
-        /// @param[in] landBoundary
-        /// @param[in] mesh
-        /// @param[in] polygons
-        /// @returns
+        /// @brief Default constructor
+        LandBoundaries() = default;
+
+        /// @brief Default constructor
+        /// @param[in] landBoundary A vector of points defining the land boundary
+        /// @param[in] mesh The current 2d mesh
+        /// @param[in] polygons A polygon for selecting part of the land boundaries
         LandBoundaries(const std::vector<Point>& landBoundary,
                        std::shared_ptr<Mesh2D> mesh,
                        std::shared_ptr<Polygons> polygons);

--- a/include/MeshKernelApi/MeshKernel.hpp
+++ b/include/MeshKernelApi/MeshKernel.hpp
@@ -195,13 +195,13 @@ namespace meshkernelapi
         /// @param[in] meshKernelId The id of the mesh state
         /// @param[in] projectToLandBoundaryOption The option to determine how to snap to land boundaries
         /// @param[in] orthogonalizationParameters The structure containing the orthogonalization parameters \ref meshkernelapi::OrthogonalizationParameters
-        /// @param[in] polygons                    The polygon where to perform the orthogonalization
+        /// @param[in] selectingPolygon                    The polygon where to perform the orthogonalization
         /// @param[in] landBoundaries              The land boundaries to account for in the orthogonalization process
         /// @returns Error code
         MKERNEL_API int mkernel_compute_orthogonalization_mesh2d(int meshKernelId,
                                                                  int projectToLandBoundaryOption,
                                                                  const OrthogonalizationParameters& orthogonalizationParameters,
-                                                                 const GeometryList& polygons,
+                                                                 const GeometryList& selectingPolygon,
                                                                  const GeometryList& landBoundaries);
 
         /// @brief Initialization of the \ref meshkernel::OrthogonalizationAndSmoothing algorithm.
@@ -211,14 +211,14 @@ namespace meshkernelapi
         /// @param[in] meshKernelId                The id of the mesh state
         /// @param[in] projectToLandBoundaryOption The option to determine how to snap to land boundaries
         /// @param[in] orthogonalizationParameters The structure containing the user defined orthogonalization parameters
-        /// @param[in] geometryListPolygon         The polygon where to perform the orthogonalization
-        /// @param[in] geometryListLandBoundaries  The land boundaries to account for in the orthogonalization process
+        /// @param[in] selectingPolygon            The polygon where to perform the orthogonalization
+        /// @param[in] landBoundaries              The land boundaries to account for in the orthogonalization process
         /// @returns Error code
         MKERNEL_API int mkernel_initialize_orthogonalization_mesh2d(int meshKernelId,
                                                                     int projectToLandBoundaryOption,
                                                                     OrthogonalizationParameters& orthogonalizationParameters,
-                                                                    const GeometryList& geometryListPolygon,
-                                                                    const GeometryList& geometryListLandBoundaries);
+                                                                    const GeometryList& selectingPolygon,
+                                                                    const GeometryList& landBoundaries);
 
         /// @brief Prepares an outer orthogonalization iteration, computing the new orthogonalization and smoothing weights from the modified mesh geometry (in interactive mode).
         ///
@@ -496,13 +496,17 @@ namespace meshkernelapi
         /// @brief Flips mesh2d edges, to optimize the mesh smoothness. This operation is usually performed after `mkernel_refine_based_on_samples_mesh2d` or `mkernel_refine_based_on_polygon_mesh2d`.
         ///
         /// Nodes that are connected to more than six other nodes are typically enclosed by faces of highly non-uniform shape and wildly varying areas.
-        /// @param[in] meshKernelId                The id of the mesh state
-        /// @param[in] isTriangulationRequired     The option to triangulate also non triangular cells (if activated squares becomes triangles)
+        /// @param[in] meshKernelId                  The id of the mesh state
+        /// @param[in] isTriangulationRequired       The option to triangulate also non triangular cells (if activated squares becomes triangles)
         /// @param[in] projectToLandBoundaryRequired The option to determine how to snap to land boundaries
+        /// @param[in] selectingPolygon              The polygon where to perform the edge flipping
+        /// @param[in] landBoundaries                The land boundaries to account for when flipping the edges
         /// @returns Error code
         MKERNEL_API int mkernel_flip_edges_mesh2d(int meshKernelId,
                                                   int isTriangulationRequired,
-                                                  int projectToLandBoundaryRequired);
+                                                  int projectToLandBoundaryRequired,
+                                                  const GeometryList& selectingPolygon,
+                                                  const GeometryList& landBoundaries);
 
         /// @brief Gets the number of obtuse mesh2d triangles. Obtuse triangles are those having one edge longer than the sum of the other two.
         /// @param[in]  meshKernelId       The id of the mesh state

--- a/include/MeshKernelApi/MeshKernel.hpp
+++ b/include/MeshKernelApi/MeshKernel.hpp
@@ -195,8 +195,8 @@ namespace meshkernelapi
         /// @param[in] meshKernelId The id of the mesh state
         /// @param[in] projectToLandBoundaryOption The option to determine how to snap to land boundaries
         /// @param[in] orthogonalizationParameters The structure containing the orthogonalization parameters \ref meshkernelapi::OrthogonalizationParameters
-        /// @param[in] selectingPolygon                    The polygon where to perform the orthogonalization
-        /// @param[in] landBoundaries              The land boundaries to account for in the orthogonalization process
+        /// @param[in] selectingPolygon            The polygon where to perform the orthogonalization  (num_coordinates = 0 for an empty polygon)
+        /// @param[in] landBoundaries              The land boundaries to account for in the orthogonalization process (num_coordinates = 0 for no land boundaries)
         /// @returns Error code
         MKERNEL_API int mkernel_compute_orthogonalization_mesh2d(int meshKernelId,
                                                                  int projectToLandBoundaryOption,
@@ -211,8 +211,8 @@ namespace meshkernelapi
         /// @param[in] meshKernelId                The id of the mesh state
         /// @param[in] projectToLandBoundaryOption The option to determine how to snap to land boundaries
         /// @param[in] orthogonalizationParameters The structure containing the user defined orthogonalization parameters
-        /// @param[in] selectingPolygon            The polygon where to perform the orthogonalization
-        /// @param[in] landBoundaries              The land boundaries to account for in the orthogonalization process
+        /// @param[in] selectingPolygon            The polygon where to perform the orthogonalization (num_coordinates = 0 for an empty polygon)
+        /// @param[in] landBoundaries              The land boundaries to account for in the orthogonalization process  (num_coordinates = 0 for no land boundaries)
         /// @returns Error code
         MKERNEL_API int mkernel_initialize_orthogonalization_mesh2d(int meshKernelId,
                                                                     int projectToLandBoundaryOption,
@@ -483,7 +483,7 @@ namespace meshkernelapi
 
         /// @brief Selects the polygon nodes within another polygon.
         /// @param[in]  meshKernelId   The id of the mesh state
-        /// @param[in]  selectingPolygon   The selecting polygon
+        /// @param[in]  selectingPolygon   The selecting polygon (num_coordinates = 0 for an empty polygon)
         /// @param[in]  polygonToSelect    The polygon to select
         /// @param[out] selectionResults   The selection result, contained in the in the values field of \ref GeometryList (0.0 not selected, 1.0 selected).
         /// Note that the selection selectionResults variable must be allocated by the client.
@@ -499,8 +499,8 @@ namespace meshkernelapi
         /// @param[in] meshKernelId                  The id of the mesh state
         /// @param[in] isTriangulationRequired       The option to triangulate also non triangular cells (if activated squares becomes triangles)
         /// @param[in] projectToLandBoundaryRequired The option to determine how to snap to land boundaries
-        /// @param[in] selectingPolygon              The polygon where to perform the edge flipping
-        /// @param[in] landBoundaries                The land boundaries to account for when flipping the edges
+        /// @param[in] selectingPolygon              The polygon where to perform the edge flipping (num_coordinates = 0 for an empty polygon)
+        /// @param[in] landBoundaries                The land boundaries to account for when flipping the edges (num_coordinates = 0 for no land boundaries)
         /// @returns Error code
         MKERNEL_API int mkernel_flip_edges_mesh2d(int meshKernelId,
                                                   int isTriangulationRequired,

--- a/include/MeshKernelApi/Utils.hpp
+++ b/include/MeshKernelApi/Utils.hpp
@@ -51,16 +51,10 @@ namespace meshkernelapi
     static std::vector<meshkernel::Point> ConvertGeometryListToPointVector(const GeometryList& geometryListIn)
     {
         std::vector<meshkernel::Point> result;
-        if (geometryListIn.num_coordinates == 0)
-        {
-            return result;
-        }
-
-        result.resize(geometryListIn.num_coordinates);
-
+        result.reserve(geometryListIn.num_coordinates);
         for (auto i = 0; i < geometryListIn.num_coordinates; i++)
         {
-            result[i] = {geometryListIn.coordinates_x[i], geometryListIn.coordinates_y[i]};
+            result.emplace_back(geometryListIn.coordinates_x[i], geometryListIn.coordinates_y[i]);
         }
         return result;
     }
@@ -75,11 +69,11 @@ namespace meshkernelapi
             throw std::invalid_argument("MeshKernel: The samples are empty.");
         }
         std::vector<meshkernel::Sample> result;
-        result.resize(geometryListIn.num_coordinates);
+        result.reserve(geometryListIn.num_coordinates);
 
         for (auto i = 0; i < geometryListIn.num_coordinates; i++)
         {
-            result[i] = {geometryListIn.coordinates_x[i], geometryListIn.coordinates_y[i], geometryListIn.values[i]};
+            result.push_back({geometryListIn.coordinates_x[i], geometryListIn.coordinates_y[i], geometryListIn.values[i]});
         }
         return result;
     }

--- a/src/MeshKernel/Polygons.cpp
+++ b/src/MeshKernel/Polygons.cpp
@@ -325,8 +325,8 @@ size_t Polygons::PolygonIndex(Point point) const
     bool inPolygon = false;
     for (auto polygonIndex = 0; polygonIndex < GetNumPolygons(); ++polygonIndex)
     {
-        auto polygonStartIndex = m_indices[polygonIndex][0];
-        auto polygonEndIndex = m_indices[polygonIndex][1];
+        auto const polygonStartIndex = m_indices[polygonIndex][0];
+        auto const polygonEndIndex = m_indices[polygonIndex][1];
 
         // Calculate the bounding box
         double XMin = std::numeric_limits<double>::max();

--- a/src/MeshKernelApi/MeshKernel.cpp
+++ b/src/MeshKernelApi/MeshKernel.cpp
@@ -1359,12 +1359,12 @@ namespace meshkernelapi
             // build the land boundary
             auto const landBoundariesNodeVector = ConvertGeometryListToPointVector(landBoundaries);
 
-            // Construct all dependencies
+            // construct all dependencies
             auto const polygon = std::make_shared<meshkernel::Polygons>(polygonNodesVector, meshKernelState[meshKernelId].m_mesh2d->m_projection);
             auto const landBoundary = std::make_shared<meshkernel::LandBoundaries>(landBoundariesNodeVector, meshKernelState[meshKernelId].m_mesh2d, polygon);
+            bool const triangulateFaces = isTriangulationRequired == 0 ? false : true;
+            bool const projectToLandBoundary = projectToLandBoundaryRequired == 0 ? false : true;
 
-            const bool triangulateFaces = isTriangulationRequired == 0 ? false : true;
-            const bool projectToLandBoundary = projectToLandBoundaryRequired == 0 ? false : true;
             const meshkernel::FlipEdges flipEdges(meshKernelState[meshKernelId].m_mesh2d, landBoundary, triangulateFaces, projectToLandBoundary);
 
             flipEdges.Compute();

--- a/src/MeshKernelApi/MeshKernel.cpp
+++ b/src/MeshKernelApi/MeshKernel.cpp
@@ -440,20 +440,10 @@ namespace meshkernelapi
             }
 
             // build the selecting polygon
-            std::vector<meshkernel::Point> polygonNodes(selectingPolygon.num_coordinates);
-            for (auto i = 0; i < selectingPolygon.num_coordinates; i++)
-            {
-                polygonNodes[i].x = selectingPolygon.coordinates_x[i];
-                polygonNodes[i].y = selectingPolygon.coordinates_y[i];
-            }
+            auto const polygonNodes = ConvertGeometryListToPointVector(selectingPolygon);
 
             // build the land boundary
-            std::vector<meshkernel::Point> landBoundariesPoints(landBoundaries.num_coordinates);
-            for (auto i = 0; i < landBoundaries.num_coordinates; i++)
-            {
-                landBoundariesPoints[i].x = landBoundaries.coordinates_x[i];
-                landBoundariesPoints[i].y = landBoundaries.coordinates_y[i];
-            }
+            auto const landBoundariesPoints = ConvertGeometryListToPointVector(landBoundaries);
 
             // Construct all dependencies
             auto const smoother = std::make_shared<meshkernel::Smoother>(meshKernelState[meshKernelId].m_mesh2d);
@@ -498,26 +488,16 @@ namespace meshkernelapi
             }
 
             // build the selecting polygon
-            std::vector<meshkernel::Point> polygonNodes(selectingPolygon.num_coordinates);
-            for (auto i = 0; i < selectingPolygon.num_coordinates; i++)
-            {
-                polygonNodes[i].x = selectingPolygon.coordinates_x[i];
-                polygonNodes[i].y = selectingPolygon.coordinates_y[i];
-            }
+            auto const polygonNodesVector = ConvertGeometryListToPointVector(selectingPolygon);
 
             // build the land boundary
-            std::vector<meshkernel::Point> landBoundariesPoints(landBoundaries.num_coordinates);
-            for (auto i = 0; i < landBoundaries.num_coordinates; i++)
-            {
-                landBoundariesPoints[i].x = landBoundaries.coordinates_x[i];
-                landBoundariesPoints[i].y = landBoundaries.coordinates_y[i];
-            }
+            auto const landBoundariesNodeVector = ConvertGeometryListToPointVector(landBoundaries);
 
             // Construct all dependencies
             auto const smoother = std::make_shared<meshkernel::Smoother>(meshKernelState[meshKernelId].m_mesh2d);
             auto const orthogonalizer = std::make_shared<meshkernel::Orthogonalizer>(meshKernelState[meshKernelId].m_mesh2d);
-            auto const polygon = std::make_shared<meshkernel::Polygons>(polygonNodes, meshKernelState[meshKernelId].m_mesh2d->m_projection);
-            auto const landBoundary = std::make_shared<meshkernel::LandBoundaries>(landBoundariesPoints, meshKernelState[meshKernelId].m_mesh2d, polygon);
+            auto const polygon = std::make_shared<meshkernel::Polygons>(polygonNodesVector, meshKernelState[meshKernelId].m_mesh2d->m_projection);
+            auto const landBoundary = std::make_shared<meshkernel::LandBoundaries>(landBoundariesNodeVector, meshKernelState[meshKernelId].m_mesh2d, polygon);
 
             meshKernelState[meshKernelId].m_meshOrthogonalization = std::make_shared<meshkernel::OrthogonalizationAndSmoothing>(meshKernelState[meshKernelId].m_mesh2d,
                                                                                                                                 smoother,
@@ -1374,24 +1354,14 @@ namespace meshkernelapi
             }
 
             // build the selecting polygon
-            std::vector<meshkernel::Point> polygonNodes(selectingPolygon.num_coordinates);
-            for (auto i = 0; i < selectingPolygon.num_coordinates; i++)
-            {
-                polygonNodes[i].x = selectingPolygon.coordinates_x[i];
-                polygonNodes[i].y = selectingPolygon.coordinates_y[i];
-            }
+            auto const polygonNodesVector = ConvertGeometryListToPointVector(selectingPolygon);
 
             // build the land boundary
-            std::vector<meshkernel::Point> landBoundariesPoints(landBoundaries.num_coordinates);
-            for (auto i = 0; i < landBoundaries.num_coordinates; i++)
-            {
-                landBoundariesPoints[i].x = landBoundaries.coordinates_x[i];
-                landBoundariesPoints[i].y = landBoundaries.coordinates_y[i];
-            }
+            auto const landBoundariesNodeVector = ConvertGeometryListToPointVector(landBoundaries);
 
             // Construct all dependencies
-            auto const polygon = std::make_shared<meshkernel::Polygons>(polygonNodes, meshKernelState[meshKernelId].m_mesh2d->m_projection);
-            auto const landBoundary = std::make_shared<meshkernel::LandBoundaries>(landBoundariesPoints, meshKernelState[meshKernelId].m_mesh2d, polygon);
+            auto const polygon = std::make_shared<meshkernel::Polygons>(polygonNodesVector, meshKernelState[meshKernelId].m_mesh2d->m_projection);
+            auto const landBoundary = std::make_shared<meshkernel::LandBoundaries>(landBoundariesNodeVector, meshKernelState[meshKernelId].m_mesh2d, polygon);
 
             const bool triangulateFaces = isTriangulationRequired == 0 ? false : true;
             const bool projectToLandBoundary = projectToLandBoundaryRequired == 0 ? false : true;
@@ -2534,7 +2504,7 @@ namespace meshkernelapi
             }
 
             // Locations
-            auto sampleValues = ConvertGeometryListToSampleVector(samples);
+            auto const sampleValues = ConvertGeometryListToSampleVector(samples);
             auto const meshLocation = static_cast<meshkernel::MeshLocations>(locationType);
             auto const locations = meshKernelState[meshKernelId].m_mesh2d->ComputeLocations(meshLocation);
 

--- a/tests/api/ApiTest.cpp
+++ b/tests/api/ApiTest.cpp
@@ -160,7 +160,7 @@ TEST_F(ApiTests, DeleteNodeThroughApi)
     ASSERT_NEAR(0.5, mesh2d.face_y[1], tolerance);
 }
 
-TEST_F(ApiTests, FlipEdgesThroughApi)
+TEST_F(ApiTests, FlipEdges_ShouldFlipEdges)
 {
     // Prepare
     MakeMesh();
@@ -171,6 +171,59 @@ TEST_F(ApiTests, FlipEdgesThroughApi)
     const int projectToLandBoundaryOption = 1;
     meshkernelapi::GeometryList selectingPolygon{};
     meshkernelapi::GeometryList landBoundaries{};
+    auto errorCode = mkernel_flip_edges_mesh2d(meshKernelId,
+                                               isTriangulationRequired,
+                                               projectToLandBoundaryOption,
+                                               selectingPolygon,
+                                               landBoundaries);
+
+    ASSERT_EQ(meshkernelapi::MeshKernelApiErrors::Success, errorCode);
+
+    meshkernelapi::Mesh2D mesh2d{};
+    errorCode = mkernel_get_dimensions_mesh2d(meshKernelId, mesh2d);
+
+    // Assert
+    ASSERT_EQ(meshkernelapi::MeshKernelApiErrors::Success, errorCode);
+    ASSERT_EQ(12, mesh2d.num_nodes);
+    ASSERT_EQ(23, mesh2d.num_edges);
+}
+
+TEST_F(ApiTests, FlipEdges_WithALandBoundary_ShouldFlipEdges)
+{
+    // Prepare
+    MakeMesh();
+    auto const meshKernelId = GetMeshKernelId();
+
+    // Execute
+    const int isTriangulationRequired = 1;
+    const int projectToLandBoundaryOption = 1;
+    meshkernelapi::GeometryList selectingPolygon{};
+
+    std::unique_ptr<double> const xCoordinates(new double[4]{
+        -0.5,
+        -0.5,
+        4.0,
+        meshkernel::doubleMissingValue});
+
+    std::unique_ptr<double> const yCoordinates(new double[4]{
+        3.0,
+        -0.5,
+        -0.5,
+        meshkernel::doubleMissingValue});
+
+    std::unique_ptr<double> const zCoordinates(new double[4]{
+        0.0,
+        0.0,
+        0.0,
+        meshkernel::doubleMissingValue});
+
+    meshkernelapi::GeometryList landBoundaries{};
+    landBoundaries.geometry_separator = meshkernel::doubleMissingValue;
+    landBoundaries.coordinates_x = xCoordinates.get();
+    landBoundaries.coordinates_y = yCoordinates.get();
+    landBoundaries.values = zCoordinates.get();
+    landBoundaries.num_coordinates = 4;
+
     auto errorCode = mkernel_flip_edges_mesh2d(meshKernelId,
                                                isTriangulationRequired,
                                                projectToLandBoundaryOption,

--- a/tests/api/ApiTest.cpp
+++ b/tests/api/ApiTest.cpp
@@ -169,7 +169,14 @@ TEST_F(ApiTests, FlipEdgesThroughApi)
     // Execute
     const int isTriangulationRequired = 1;
     const int projectToLandBoundaryOption = 1;
-    auto errorCode = meshkernelapi::mkernel_flip_edges_mesh2d(meshKernelId, isTriangulationRequired, projectToLandBoundaryOption);
+    meshkernelapi::GeometryList selectingPolygon{};
+    meshkernelapi::GeometryList landBoundaries{};
+    auto errorCode = mkernel_flip_edges_mesh2d(meshKernelId,
+                                               isTriangulationRequired,
+                                               projectToLandBoundaryOption,
+                                               selectingPolygon,
+                                               landBoundaries);
+
     ASSERT_EQ(meshkernelapi::MeshKernelApiErrors::Success, errorCode);
 
     meshkernelapi::Mesh2D mesh2d{};


### PR DESCRIPTION
+ document LandBoundaries constructor
+ rename some of the api parameters for clarity
+ pass landboundaries and selecting polygon to mkernel_flip_edges_mesh2d
+ adapt FlipEdgesThroughApi ApiTest accordinglt