### PR TITLE
GRIDEDIT-405:Averaging algorithm is not working properly for edge data points

### DIFF
--- a/src/MeshKernel/AveragingInterpolation.cpp
+++ b/src/MeshKernel/AveragingInterpolation.cpp
@@ -85,14 +85,6 @@ void AveragingInterpolation::Compute()
             {
                 m_results[e] = (firstValue + secondValue) * 0.5;
             }
-            else if (IsEqual(firstValue, doubleMissingValue))
-            {
-                m_results[e] = secondValue;
-            }
-            else if (IsEqual(secondValue, doubleMissingValue))
-            {
-                m_results[e] = firstValue;
-            }
         }
         return;
     }
@@ -258,7 +250,7 @@ double AveragingInterpolation::ComputeOnPolygon(const std::vector<Point>& polygo
         throw std::invalid_argument("AveragingInterpolation::ComputeOnPolygon invalid interpolation point");
     }
 
-    std::vector<Point> const searchPolygon = GetSearchPolygon(polygon, interpolationPoint);
+    auto const searchPolygon = GetSearchPolygon(polygon, interpolationPoint);
 
     double const searchRadiusSquared = GetSearchRadiusSquared(searchPolygon, interpolationPoint);
 

--- a/src/MeshKernel/AveragingStrategies/InverseWeightedAveragingStrategy.cpp
+++ b/src/MeshKernel/AveragingStrategies/InverseWeightedAveragingStrategy.cpp
@@ -19,6 +19,6 @@ namespace meshkernel::averaging
 
     double InverseWeightedAveragingStrategy::Calculate() const
     {
-        return m_wall > m_minNumSamples ? m_result / m_wall : doubleMissingValue;
+        return m_wall >= m_minNumSamples ? m_result / m_wall : doubleMissingValue;
     }
 } // namespace meshkernel::averaging

--- a/src/MeshKernel/AveragingStrategies/SimpleAveragingStrategy.cpp
+++ b/src/MeshKernel/AveragingStrategies/SimpleAveragingStrategy.cpp
@@ -40,6 +40,6 @@ namespace meshkernel::averaging
 
     double SimpleAveragingStrategy::Calculate() const
     {
-        return m_nAdds > m_minNumPoints ? m_result / static_cast<double>(m_nAdds) : doubleMissingValue;
+        return m_nAdds >= m_minNumPoints ? m_result / static_cast<double>(m_nAdds) : doubleMissingValue;
     }
 } // namespace meshkernel::averaging

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(MeshKernelUnitTests ${UNIT_TEST_LIST})
 
 # Should be linked to the main library, as well as the google test library
 target_link_libraries(MeshKernelUnitTests PRIVATE MeshKernel UtilsStatic
-                                                  gtest_main)
+                                                  gtest_main gmock)
 
 # Make sure that coverage information is produced when using gcc
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")


### PR DESCRIPTION
+ values on edges are computed only if interpolated values are present on both nodes
+ correct SimpleAveragingStrategy::Calculate(), m_nAdds is the minimum amount of available samples, included
+ add unit tests