### PR TITLE
GRIDEDIT-790: bind mesh2d projection conversion

### DIFF
--- a/libs/MeshKernel/src/Definitions.cpp
+++ b/libs/MeshKernel/src/Definitions.cpp
@@ -5,7 +5,7 @@ meshkernel::Projection meshkernel::GetProjectionValue(const int projection)
 {
     static const int Cartesian = static_cast<int>(Projection::cartesian);
     static const int Spherical = static_cast<int>(Projection::spherical);
-    static const int Accurate = static_cast<int>(Projection::sphericalAccurate);
+    static const int SphericalAccurate = static_cast<int>(Projection::sphericalAccurate);
 
     if (projection == Cartesian)
     {
@@ -15,7 +15,7 @@ meshkernel::Projection meshkernel::GetProjectionValue(const int projection)
     {
         return Projection::spherical;
     }
-    else if (projection == Accurate)
+    else if (projection == SphericalAccurate)
     {
         return Projection::sphericalAccurate;
     }
@@ -29,7 +29,7 @@ const std::string& meshkernel::ToString(const Projection projection)
 {
     static const std::string Cartesian = "Projection::Cartesian";
     static const std::string Spherical = "Projection::Spherical";
-    static const std::string Accurate = "Projection::SphericalAccurate";
+    static const std::string SphericalAccurate = "Projection::SphericalAccurate";
     static const std::string Unknown = "UNKNOWN";
 
     switch (projection)
@@ -39,7 +39,7 @@ const std::string& meshkernel::ToString(const Projection projection)
     case Projection::spherical:
         return Spherical;
     case Projection::sphericalAccurate:
-        return Accurate;
+        return SphericalAccurate;
     default:
         return Unknown;
     }

--- a/libs/MeshKernel/tests/src/MeshConversionTests.cpp
+++ b/libs/MeshKernel/tests/src/MeshConversionTests.cpp
@@ -206,7 +206,7 @@ TEST(MeshConversionTests, CartesianToSphericalClassTestFromStringZone31)
     EXPECT_TRUE(mk::IsEqual(target.y, result.y, tolerance));
 }
 
-TEST(MeshConversionTests, CartesianToSphericalClassTestFromStringZone30)
+TEST(MeshConversionTests, CartesianToSphericalClassTestFromStringZone30N)
 {
     constexpr double tolerance = 1.0e-6;
 

--- a/libs/MeshKernelApi/include/MeshKernelApi/MeshKernel.hpp
+++ b/libs/MeshKernelApi/include/MeshKernelApi/MeshKernel.hpp
@@ -775,13 +775,13 @@ namespace meshkernelapi
         /// @returns Error code
         MKERNEL_API int mkernel_mesh2d_connect_meshes(int meshKernelId, const Mesh2D& mesh2d, double searchFraction);
 
-        /// @brief Change the projection of a mesh2d.
+        /// @brief Converts the projection of a mesh2d.
         ///
         /// @param[in] meshKernelId The id of the mesh state
-        /// @param[in] projectionType new projection for the mesh
+        /// @param[in] projectionType The new projection for the mesh
         /// @param[in] zoneString The UTM zone and information string
         /// @returns Error code
-        MKERNEL_API int mkernel_mesh2d_convert(int meshKernelId, int projectionType, const std::string& zoneString);
+        MKERNEL_API int mkernel_mesh2d_convert_projection(int meshKernelId, int projectionType, const char* const zoneString);
 
         /// @brief Count the number of hanging edges in a mesh2d.
         /// An hanging edge is an edge where one of the two nodes is not connected.

--- a/libs/MeshKernelApi/src/MeshKernel.cpp
+++ b/libs/MeshKernelApi/src/MeshKernel.cpp
@@ -624,7 +624,7 @@ namespace meshkernelapi
         return lastExitCode;
     }
 
-    MKERNEL_API int mkernel_mesh2d_convert(int meshKernelId, int projectionType, const std::string& zoneString)
+    MKERNEL_API int mkernel_mesh2d_convert_projection(int meshKernelId, int projectionType, const char* const zoneString)
     {
         lastExitCode = meshkernel::ExitCode::Success;
         try
@@ -636,22 +636,27 @@ namespace meshkernelapi
 
             const meshkernel::Projection projection = meshkernel::GetProjectionValue(projectionType);
 
+            // const meshkernel::Projection& proj = meshKernelState[meshKernelId].m_mesh2d->m_projection;
+
             if (meshKernelState[meshKernelId].m_mesh2d->m_projection != projection)
             {
-                if (meshKernelState[meshKernelId].m_projection == meshkernel::Projection::cartesian)
+                if (meshKernelState[meshKernelId].m_mesh2d->m_projection == meshkernel::Projection::cartesian)
                 {
                     meshkernel::ConvertCartesianToSpherical conversion(zoneString);
                     meshkernel::MeshConversion::Compute(*meshKernelState[meshKernelId].m_mesh2d, conversion);
+                    meshKernelState[meshKernelId].m_projection = conversion.TargetProjection();
                 }
-                else if (meshKernelState[meshKernelId].m_projection == meshkernel::Projection::spherical)
+                else if (meshKernelState[meshKernelId].m_mesh2d->m_projection == meshkernel::Projection::spherical)
                 {
                     meshkernel::ConvertSphericalToCartesian conversion(zoneString);
                     meshkernel::MeshConversion::Compute(*meshKernelState[meshKernelId].m_mesh2d, conversion);
+                    meshKernelState[meshKernelId].m_projection = conversion.TargetProjection();
                 }
                 else
                 {
                     throw meshkernel::MeshKernelError("Mesh conversion between projection {} and {} has not been implemented.",
-                                                      meshkernel::ToString(meshKernelState[meshKernelId].m_projection), meshkernel::ToString(projection));
+                                                      meshkernel::ToString(meshKernelState[meshKernelId].m_projection),
+                                                      meshkernel::ToString(projection));
                 }
             }
         }

--- a/libs/MeshKernelApi/src/MeshKernel.cpp
+++ b/libs/MeshKernelApi/src/MeshKernel.cpp
@@ -634,19 +634,19 @@ namespace meshkernelapi
                 throw meshkernel::MeshKernelError("The selected mesh kernel id does not exist.");
             }
 
-            const meshkernel::Projection projection = meshkernel::GetProjectionValue(projectionType);
+            const meshkernel::Projection targetProjection = meshkernel::GetProjectionValue(projectionType);
 
-            // const meshkernel::Projection& proj = meshKernelState[meshKernelId].m_mesh2d->m_projection;
+            const meshkernel::Projection& sourceProjection = meshKernelState[meshKernelId].m_mesh2d->m_projection;
 
-            if (meshKernelState[meshKernelId].m_mesh2d->m_projection != projection)
+            if (sourceProjection != targetProjection)
             {
-                if (meshKernelState[meshKernelId].m_mesh2d->m_projection == meshkernel::Projection::cartesian)
+                if (sourceProjection == meshkernel::Projection::cartesian)
                 {
                     meshkernel::ConvertCartesianToSpherical conversion(zoneString);
                     meshkernel::MeshConversion::Compute(*meshKernelState[meshKernelId].m_mesh2d, conversion);
                     meshKernelState[meshKernelId].m_projection = conversion.TargetProjection();
                 }
-                else if (meshKernelState[meshKernelId].m_mesh2d->m_projection == meshkernel::Projection::spherical)
+                else if (sourceProjection == meshkernel::Projection::spherical)
                 {
                     meshkernel::ConvertSphericalToCartesian conversion(zoneString);
                     meshkernel::MeshConversion::Compute(*meshKernelState[meshKernelId].m_mesh2d, conversion);
@@ -655,8 +655,8 @@ namespace meshkernelapi
                 else
                 {
                     throw meshkernel::MeshKernelError("Mesh conversion between projection {} and {} has not been implemented.",
-                                                      meshkernel::ToString(meshKernelState[meshKernelId].m_projection),
-                                                      meshkernel::ToString(projection));
+                                                      meshkernel::ToString(sourceProjection),
+                                                      meshkernel::ToString(targetProjection));
                 }
             }
         }

--- a/libs/MeshKernelApi/tests/src/ApiTest.cpp
+++ b/libs/MeshKernelApi/tests/src/ApiTest.cpp
@@ -2670,6 +2670,106 @@ TEST_F(CartesianApiTestFixture, RotateMesh)
     }
 }
 
+TEST_F(CartesianApiTestFixture, ConvertProjection)
+{
+    // Prepare
+
+    MakeMesh();
+    auto const meshKernelId = GetMeshKernelId();
+
+    meshkernelapi::Mesh2D mesh2d{};
+    int errorCode = mkernel_mesh2d_get_dimensions(meshKernelId, mesh2d);
+    ASSERT_EQ(meshkernel::ExitCode::Success, errorCode);
+
+    // Get copy of original mesh
+    // Will be used later to compare with translated mesh
+    std::vector<int> edge_faces(mesh2d.num_edges * 2);
+    std::vector<int> edge_nodes(mesh2d.num_edges * 2);
+    std::vector<int> face_nodes(mesh2d.num_face_nodes);
+    std::vector<int> face_edges(mesh2d.num_face_nodes);
+    std::vector<int> nodes_per_face(mesh2d.num_faces);
+    std::vector<double> node_x(mesh2d.num_nodes);
+    std::vector<double> node_y(mesh2d.num_nodes);
+    std::vector<double> edge_x(mesh2d.num_edges);
+    std::vector<double> edge_y(mesh2d.num_edges);
+    std::vector<double> face_x(mesh2d.num_faces);
+    std::vector<double> face_y(mesh2d.num_faces);
+
+    mesh2d.edge_faces = edge_faces.data();
+    mesh2d.edge_nodes = edge_nodes.data();
+    mesh2d.face_nodes = face_nodes.data();
+    mesh2d.face_edges = face_edges.data();
+    mesh2d.nodes_per_face = nodes_per_face.data();
+    mesh2d.node_x = node_x.data();
+    mesh2d.node_y = node_y.data();
+    mesh2d.edge_x = edge_x.data();
+    mesh2d.edge_y = edge_y.data();
+    mesh2d.face_x = face_x.data();
+    mesh2d.face_y = face_y.data();
+    errorCode = mkernel_mesh2d_get_data(meshKernelId, mesh2d);
+
+    {
+        std::string const zoneString("+proj=utm +lat_1=0.5 +lat_2=2 +n=0.5 +zone=31");
+
+        // The mesh above has Cartesian projection, convert it to spherical
+        int target_projection = 1;
+        errorCode = meshkernelapi::mkernel_mesh2d_convert_projection(meshKernelId, target_projection, zoneString.c_str());
+        ASSERT_EQ(meshkernel::ExitCode::Success, errorCode);
+
+        int projection;
+        errorCode = meshkernelapi::mkernel_get_projection(meshKernelId, projection);
+        ASSERT_EQ(meshkernel::ExitCode::Success, errorCode);
+        ASSERT_EQ(target_projection, projection);
+
+        // Round trip back to Cartesian
+        target_projection = 0;
+        errorCode = meshkernelapi::mkernel_mesh2d_convert_projection(meshKernelId, target_projection, zoneString.c_str());
+        ASSERT_EQ(meshkernel::ExitCode::Success, errorCode);
+        errorCode = meshkernelapi::mkernel_get_projection(meshKernelId, projection);
+        ASSERT_EQ(target_projection, projection);
+    }
+
+    meshkernelapi::Mesh2D mesh2dConvertedProjection{};
+    errorCode = mkernel_mesh2d_get_dimensions(meshKernelId, mesh2dConvertedProjection);
+    ASSERT_EQ(meshkernel::ExitCode::Success, errorCode);
+
+    // Data for translated mesh
+    std::vector<int> edge_faces_t(mesh2dConvertedProjection.num_edges * 2);
+    std::vector<int> edge_nodes_t(mesh2dConvertedProjection.num_edges * 2);
+    std::vector<int> face_nodes_t(mesh2dConvertedProjection.num_face_nodes);
+    std::vector<int> face_edges_t(mesh2dConvertedProjection.num_face_nodes);
+    std::vector<int> nodes_per_face_t(mesh2dConvertedProjection.num_faces);
+    std::vector<double> node_x_t(mesh2dConvertedProjection.num_nodes);
+    std::vector<double> node_y_t(mesh2dConvertedProjection.num_nodes);
+    std::vector<double> edge_x_t(mesh2dConvertedProjection.num_edges);
+    std::vector<double> edge_y_t(mesh2dConvertedProjection.num_edges);
+    std::vector<double> face_x_t(mesh2dConvertedProjection.num_faces);
+    std::vector<double> face_y_t(mesh2dConvertedProjection.num_faces);
+
+    mesh2dConvertedProjection.edge_faces = edge_faces_t.data();
+    mesh2dConvertedProjection.edge_nodes = edge_nodes_t.data();
+    mesh2dConvertedProjection.face_nodes = face_nodes_t.data();
+    mesh2dConvertedProjection.face_edges = face_edges_t.data();
+    mesh2dConvertedProjection.nodes_per_face = nodes_per_face_t.data();
+    mesh2dConvertedProjection.node_x = node_x_t.data();
+    mesh2dConvertedProjection.node_y = node_y_t.data();
+    mesh2dConvertedProjection.edge_x = edge_x_t.data();
+    mesh2dConvertedProjection.edge_y = edge_y_t.data();
+    mesh2dConvertedProjection.face_x = face_x_t.data();
+    mesh2dConvertedProjection.face_y = face_y_t.data();
+
+    errorCode = mkernel_mesh2d_get_data(meshKernelId, mesh2dConvertedProjection);
+    ASSERT_EQ(meshkernel::ExitCode::Success, errorCode);
+
+    constexpr double tolerance = 1e-6;
+
+    for (int i = 0; i < mesh2d.num_nodes; ++i)
+    {
+        EXPECT_NEAR(mesh2d.node_x[i], mesh2dConvertedProjection.node_x[i], tolerance);
+        EXPECT_NEAR(mesh2d.node_y[i], mesh2dConvertedProjection.node_y[i], tolerance);
+    }
+}
+
 TEST(Mesh1D, Mesh1DSetAndAdd)
 {
     using namespace meshkernelapi;


### PR DESCRIPTION
A bit of work that was necessary in the back-end  before implementing the python bindings. 