### PR TITLE
Feature/gridedit 802 crash in curvilinear grid generation

### DIFF
--- a/libs/MeshKernel/include/MeshKernel/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.hpp
+++ b/libs/MeshKernel/include/MeshKernel/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.hpp
@@ -105,9 +105,12 @@ namespace meshkernel
         std::vector<std::vector<double>> m_splineIntersectionRatios;             ///< For each spline, stores the intersections in terms of total spline length
         std::vector<std::vector<UInt>> m_splineGroupIndexAndFromToIntersections; ///< For each spline: position in m or n group, from and to spline crossing indices (MN12)
         UInt m_numMSplines = 0;                                                  ///< The index of the last m spline
-        UInt m_numNSplines = 0;                                                  ///< The index of the last m spline
-        UInt m_numM = 0;                                                         ///< Number of m columns
-        UInt m_numN = 0;                                                         ///< Number of n rows
+        UInt m_numNSplines = 0;                                                  ///< The index of the last n spline
+        UInt m_mSplinesCount = 0;                                                ///< The index of the last m spline
+        UInt m_nSplinesCount = 0;                                                ///< The index of the last n spline
+
+        UInt m_numM = 0; ///< Number of m columns
+        UInt m_numN = 0; ///< Number of n rows
     };
 
 } // namespace meshkernel

--- a/libs/MeshKernel/include/MeshKernel/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.hpp
+++ b/libs/MeshKernel/include/MeshKernel/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.hpp
@@ -71,13 +71,6 @@ namespace meshkernel
                                         UInt startSecond,
                                         UInt endSecond);
 
-        /// @brief Swap the rows of a two dimensional vector
-        /// @param v The input vector
-        /// @param firstRow The first row
-        /// @param secondRow The second row
-        template <typename T>
-        void SwapRows(std::vector<std::vector<T>>& v, UInt firstRow, UInt secondRow) const;
-
         /// @brief Swap the columns of a two dimensional vector (MAKESR)
         /// @tparam T The input vector
         /// @param v

--- a/libs/MeshKernel/include/MeshKernel/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.hpp
+++ b/libs/MeshKernel/include/MeshKernel/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.hpp
@@ -48,11 +48,6 @@ namespace meshkernel
         /// @returns
         CurvilinearGridFromSplinesTransfinite(std::shared_ptr<Splines> splines, const CurvilinearParameters& curvilinearParameters);
 
-        /// @brief Computes the adimensional intersections between splines.
-        ///
-        /// Also orders the m splines (the horizontal ones) before the n splines (the vertical ones)
-        void ComputeIntersections();
-
         /// Computes the curvilinear grid from the splines using transfinite interpolation
         /// @param curvilinearGrid
         CurvilinearGrid Compute();
@@ -60,6 +55,24 @@ namespace meshkernel
         std::shared_ptr<Splines> m_splines; ///< A pointer to spline
 
     private:
+        /// @brief Characterise the splines
+        ///
+        /// finds intersections and orders the splines
+        void CharacteriseSplines();
+
+        /// @brief Label each spline and its intersection.
+        ///
+        /// In which group does it lie (m or n), and spline crossing indices.
+        void ClassifySplineIntersections();
+
+        /// @brief Computes the adimensional intersections between splines.
+        ///
+        /// Also orders the m splines (the horizontal ones) before the n splines (the vertical ones)
+        void ComputeInteractions();
+
+        /// @brief Organise the splines by spline type (vertical or horizontal)
+        void OrganiseSplines();
+
         /// @brief Order the splines such that their index increases in m or n direction
         /// @param[in] startFirst
         /// @param[in] endFirst
@@ -70,10 +83,6 @@ namespace meshkernel
                                         UInt endFirst,
                                         UInt startSecond,
                                         UInt endSecond);
-
-        /// @brief Order the splines by spline type (vertical or horizontal)
-        /// @param[in] numSplines The number of splines
-        void OrderSplinesByType(UInt numSplines);
 
         /// @brief Swap the columns of a two dimensional vector (MAKESR)
         /// @tparam T The input vector

--- a/libs/MeshKernel/include/MeshKernel/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.hpp
+++ b/libs/MeshKernel/include/MeshKernel/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.hpp
@@ -71,6 +71,10 @@ namespace meshkernel
                                         UInt startSecond,
                                         UInt endSecond);
 
+        /// @brief Order the splines by spline type (vertical or horizontal)
+        /// @param[in] numSplines The number of splines
+        void OrderSplinesByType(UInt numSplines);
+
         /// @brief Swap the columns of a two dimensional vector (MAKESR)
         /// @tparam T The input vector
         /// @param v
@@ -106,8 +110,6 @@ namespace meshkernel
         std::vector<std::vector<UInt>> m_splineGroupIndexAndFromToIntersections; ///< For each spline: position in m or n group, from and to spline crossing indices (MN12)
         UInt m_numMSplines = 0;                                                  ///< The index of the last m spline
         UInt m_numNSplines = 0;                                                  ///< The index of the last n spline
-        UInt m_mSplinesCount = 0;                                                ///< The index of the last m spline
-        UInt m_nSplinesCount = 0;                                                ///< The index of the last n spline
 
         UInt m_numM = 0; ///< Number of m columns
         UInt m_numN = 0; ///< Number of n rows

--- a/libs/MeshKernel/src/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.cpp
+++ b/libs/MeshKernel/src/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.cpp
@@ -147,7 +147,6 @@ CurvilinearGrid CurvilinearGridFromSplinesTransfinite::Compute()
                                                                                                              false,
                                                                                                              distances);
 
-
         // Start filling curvilinear grid
         UInt index = 0;
         for (auto i = from; i < to; i++)
@@ -546,10 +545,10 @@ bool CurvilinearGridFromSplinesTransfinite::OrderSplines(UInt startFirst,
                 }
 
                 // they must be swapped
-                m_splines->m_splineNodes[j].swap (m_splines->m_splineNodes[k]);
-                m_splines->m_splineDerivatives[j].swap (m_splines->m_splineDerivatives[k]);
+                m_splines->m_splineNodes[j].swap(m_splines->m_splineNodes[k]);
+                m_splines->m_splineDerivatives[j].swap(m_splines->m_splineDerivatives[k]);
                 std::swap(m_splines->m_splinesLength[j], m_splines->m_splinesLength[k]);
-                m_splineIntersectionRatios[j].swap (m_splineIntersectionRatios[k]);
+                m_splineIntersectionRatios[j].swap(m_splineIntersectionRatios[k]);
 
                 SwapColumns(m_splineIntersectionRatios, j, k);
 

--- a/libs/MeshKernel/src/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.cpp
+++ b/libs/MeshKernel/src/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.cpp
@@ -147,23 +147,6 @@ CurvilinearGrid CurvilinearGridFromSplinesTransfinite::Compute()
                                                                                                              false,
                                                                                                              distances);
 
-        std::cout << "distances:  ";
-
-        for (UInt i = 0; i < distances.size(); ++i)
-        {
-            std::cout << distances[i] << " ";
-        }
-
-        std::cout << std::endl;
-
-        std::cout << "points: " << splineIndex << "  ";
-
-        for (UInt i = 0; i < points.size(); ++i)
-        {
-            std::cout << "{ " << points[i].x << ", " << points[i].y << "} ";
-        }
-
-        std::cout << std::endl;
 
         // Start filling curvilinear grid
         UInt index = 0;
@@ -179,32 +162,6 @@ CurvilinearGrid CurvilinearGridFromSplinesTransfinite::Compute()
             }
             index++;
         }
-    }
-
-    std::cout << std::endl;
-    std::cout << std::endl;
-
-    for (UInt j = 0; j < TotalNRows + 1; ++j)
-    {
-        for (UInt i = 0; i < TotalMColumns + 1; ++i)
-        {
-            std::cout << gridNodes(i, j).x << " ";
-        }
-
-        std::cout << std::endl;
-    }
-
-    std::cout << std::endl;
-    std::cout << std::endl;
-
-    for (UInt j = 0; j < TotalNRows + 1; ++j)
-    {
-        for (UInt i = 0; i < TotalMColumns + 1; ++i)
-        {
-            std::cout << gridNodes(i, j).y << " ";
-        }
-
-        std::cout << std::endl;
     }
 
     sideOne.resize(numNPoints);
@@ -274,33 +231,6 @@ CurvilinearGrid CurvilinearGridFromSplinesTransfinite::Compute()
                 }
             }
         }
-    }
-
-    std::cout << std::endl;
-    std::cout << "after interplation" << std::endl;
-    std::cout << std::endl;
-
-    for (UInt j = 0; j < TotalNRows + 1; ++j)
-    {
-        for (UInt i = 0; i < TotalMColumns + 1; ++i)
-        {
-            std::cout << gridNodes(i, j).x << " ";
-        }
-
-        std::cout << std::endl;
-    }
-
-    std::cout << std::endl;
-    std::cout << std::endl;
-
-    for (UInt j = 0; j < TotalNRows + 1; ++j)
-    {
-        for (UInt i = 0; i < TotalMColumns + 1; ++i)
-        {
-            std::cout << gridNodes(i, j).y << " ";
-        }
-
-        std::cout << std::endl;
     }
 
     return CurvilinearGrid(gridNodes, m_splines->m_projection);
@@ -614,9 +544,13 @@ bool CurvilinearGridFromSplinesTransfinite::OrderSplines(UInt startFirst,
                 {
                     continue;
                 }
+
                 // they must be swapped
-                SwapRows(m_splines->m_splineNodes, j, k);
-                SwapRows(m_splineIntersectionRatios, j, k);
+                m_splines->m_splineNodes[j].swap (m_splines->m_splineNodes[k]);
+                m_splines->m_splineDerivatives[j].swap (m_splines->m_splineDerivatives[k]);
+                std::swap(m_splines->m_splinesLength[j], m_splines->m_splinesLength[k]);
+                m_splineIntersectionRatios[j].swap (m_splineIntersectionRatios[k]);
+
                 SwapColumns(m_splineIntersectionRatios, j, k);
 
                 // repeat the entire procedure once more
@@ -626,18 +560,6 @@ bool CurvilinearGridFromSplinesTransfinite::OrderSplines(UInt startFirst,
     }
 
     return true;
-}
-
-template <typename T>
-void CurvilinearGridFromSplinesTransfinite::SwapRows(std::vector<std::vector<T>>& v, UInt firstRow, UInt secondRow) const
-{
-    auto minSize = std::min(static_cast<UInt>(v[firstRow].size()), static_cast<UInt>(v[secondRow].size()));
-    minSize = std::min(minSize, m_splines->GetNumSplines());
-
-    for (UInt i = 0; i < minSize; i++)
-    {
-        std::swap(v[firstRow][i], v[secondRow][i]);
-    }
 }
 
 template <typename T>

--- a/libs/MeshKernel/src/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.cpp
+++ b/libs/MeshKernel/src/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.cpp
@@ -147,6 +147,24 @@ CurvilinearGrid CurvilinearGridFromSplinesTransfinite::Compute()
                                                                                                              false,
                                                                                                              distances);
 
+        std::cout << "distances:  ";
+
+        for (UInt i = 0; i < distances.size(); ++i)
+        {
+            std::cout << distances[i] << " ";
+        }
+
+        std::cout << std::endl;
+
+        std::cout << "points: " << splineIndex << "  ";
+
+        for (UInt i = 0; i < points.size(); ++i)
+        {
+            std::cout << "{ " << points[i].x << ", " << points[i].y << "} ";
+        }
+
+        std::cout << std::endl;
+
         // Start filling curvilinear grid
         UInt index = 0;
         for (auto i = from; i < to; i++)
@@ -161,6 +179,32 @@ CurvilinearGrid CurvilinearGridFromSplinesTransfinite::Compute()
             }
             index++;
         }
+    }
+
+    std::cout << std::endl;
+    std::cout << std::endl;
+
+    for (UInt j = 0; j < TotalNRows + 1; ++j)
+    {
+        for (UInt i = 0; i < TotalMColumns + 1; ++i)
+        {
+            std::cout << gridNodes(i, j).x << " ";
+        }
+
+        std::cout << std::endl;
+    }
+
+    std::cout << std::endl;
+    std::cout << std::endl;
+
+    for (UInt j = 0; j < TotalNRows + 1; ++j)
+    {
+        for (UInt i = 0; i < TotalMColumns + 1; ++i)
+        {
+            std::cout << gridNodes(i, j).y << " ";
+        }
+
+        std::cout << std::endl;
     }
 
     sideOne.resize(numNPoints);
@@ -230,6 +274,33 @@ CurvilinearGrid CurvilinearGridFromSplinesTransfinite::Compute()
                 }
             }
         }
+    }
+
+    std::cout << std::endl;
+    std::cout << "after interplation" << std::endl;
+    std::cout << std::endl;
+
+    for (UInt j = 0; j < TotalNRows + 1; ++j)
+    {
+        for (UInt i = 0; i < TotalMColumns + 1; ++i)
+        {
+            std::cout << gridNodes(i, j).x << " ";
+        }
+
+        std::cout << std::endl;
+    }
+
+    std::cout << std::endl;
+    std::cout << std::endl;
+
+    for (UInt j = 0; j < TotalNRows + 1; ++j)
+    {
+        for (UInt i = 0; i < TotalMColumns + 1; ++i)
+        {
+            std::cout << gridNodes(i, j).y << " ";
+        }
+
+        std::cout << std::endl;
     }
 
     return CurvilinearGrid(gridNodes, m_splines->m_projection);

--- a/libs/MeshKernel/src/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.cpp
+++ b/libs/MeshKernel/src/CurvilinearGrid/CurvilinearGridFromSplinesTransfinite.cpp
@@ -84,8 +84,12 @@ CurvilinearGrid CurvilinearGridFromSplinesTransfinite::Compute()
     sideFour.reserve(maxNumPoints);
 
     // Allocate the curvilinear grid. We can have multiple divisions along N and M.
-    const auto TotalMColumns = (m_numNSplines - 1) * m_numM;
-    const auto TotalNRows = (m_numMSplines - 1) * m_numN;
+    const auto TotalMColumns = (m_nSplinesCount - 1) * m_numM;
+    const auto TotalNRows = (m_mSplinesCount - 1) * m_numN;
+
+    // const auto TotalMColumns = (m_numNSplines - 1) * m_numM;
+    // const auto TotalNRows = (m_numMSplines - 1) * m_numN;
+
     lin_alg::Matrix<Point> gridNodes(TotalMColumns + 1, TotalNRows + 1);
 
     UInt numMSplines = 0;
@@ -319,6 +323,18 @@ void CurvilinearGridFromSplinesTransfinite::ComputeIntersections()
 {
     const auto numSplines = m_splines->GetNumSplines();
 
+    for (UInt i = 0; i < numSplines; ++i)
+    {
+        std::cout << " before spline " << i << " = ";
+
+        for (UInt j = 0; j < m_splines->m_splineNodes[i].size(); ++j)
+        {
+            std::cout << "{ " << m_splines->m_splineNodes[i][j].x << ", " << m_splines->m_splineNodes[i][j].y << " } ";
+        }
+
+        std::cout << std::endl;
+    }
+
     // fill the splines with zeros
     m_splineType.resize(numSplines);
     std::fill(m_splineType.begin(), m_splineType.end(), 0);
@@ -343,6 +359,8 @@ void CurvilinearGridFromSplinesTransfinite::ComputeIntersections()
 
             if (areCrossing)
             {
+                std::cout << " intersectionPoint " << i << "  " << j << " -- { " << intersectionPoint.x << ", " << intersectionPoint.y << " }  " << firstSplineRatio << "  " << secondSplineRatio << std::endl;
+
                 if (m_splineType[i] * m_splineType[j] == 1)
                 {
                     throw std::invalid_argument("CurvilinearGridFromSplinesTransfinite::Compute: At least two splines are intersecting twice.");
@@ -356,6 +374,8 @@ void CurvilinearGridFromSplinesTransfinite::ComputeIntersections()
                     m_splineType[j] = -m_splineType[i];
                     if (crossProductIntersection * m_splineType[i] < 0.0)
                     {
+                        std::cout << " reversing spline " << j << std::endl;
+
                         // switch j
                         std::ranges::reverse(m_splines->m_splineNodes[j]);
                         secondSplineRatio = static_cast<double>(numNodesJSpline) - 1.0 - secondSplineRatio;
@@ -366,15 +386,36 @@ void CurvilinearGridFromSplinesTransfinite::ComputeIntersections()
                     m_splineType[i] = -m_splineType[j];
                     if (crossProductIntersection * m_splineType[j] > 0.0)
                     {
+                        std::cout << " reversing spline " << i << std::endl;
                         // switch i
                         std::ranges::reverse(m_splines->m_splineNodes[i]);
                         firstSplineRatio = static_cast<double>(numNodesISpline) - 1.0 - firstSplineRatio;
                     }
                 }
+
                 m_splineIntersectionRatios[i][j] = firstSplineRatio;
                 m_splineIntersectionRatios[j][i] = secondSplineRatio;
+
+                std::cout << "m_splineIntersectionRatios " << i << "  " << j << "  " << firstSplineRatio << "  " << secondSplineRatio << std::endl;
             }
         }
+    }
+
+    for (UInt i = 0; i < numSplines; ++i)
+    {
+        std::cout << " after spline " << i << " = ";
+
+        for (UInt j = 0; j < m_splines->m_splineNodes[i].size(); ++j)
+        {
+            std::cout << "{ " << m_splines->m_splineNodes[i][j].x << ", " << m_splines->m_splineNodes[i][j].y << " } ";
+        }
+
+        std::cout << std::endl;
+    }
+
+    for (UInt i = 0; i < numSplines; i++)
+    {
+        std::cout << "m_splineType[i] " << m_splineType[i] << std::endl;
     }
 
     for (UInt i = 0; i < numSplines; i++)
@@ -385,9 +426,38 @@ void CurvilinearGridFromSplinesTransfinite::ComputeIntersections()
         }
     }
 
+    for (UInt i = 0; i < m_splineIntersectionRatios.size(); ++i)
+    {
+        std::cout << "  m_splineIntersectionRatios ";
+
+        for (UInt j = 0; j < m_splineIntersectionRatios[i].size(); ++j)
+        {
+            std::cout << std::setw(10) << m_splineIntersectionRatios[i][j] << "  ";
+        }
+
+        std::cout << std::endl;
+    }
+
+    for (UInt i = 0; i < m_splineIntersectionRatios.size(); ++i)
+    {
+        for (UInt j = 0; j < m_splineIntersectionRatios[i].size(); ++j)
+        {
+            std::cout << "  m_splineIntersectionRatios[" << i << "][" << j << "] " << m_splineIntersectionRatios[i][j] << std::endl;
+        }
+
+        std::cout << std::endl;
+    }
+
+    std::cout << "--------------------------------" << std::endl;
+
     // find the first non m_m spline
     m_numMSplines = FindIndex(m_splineType, -1);
     m_numNSplines = numSplines - m_numMSplines;
+
+    std::cout << " number of splines: " << m_numMSplines << "  " << m_numNSplines << std::endl;
+
+    m_mSplinesCount = 2;
+    m_nSplinesCount = 2;
 
     const UInt maxExternalIterations = 10;
     for (UInt i = 0; i < maxExternalIterations; i++)
@@ -424,6 +494,16 @@ void CurvilinearGridFromSplinesTransfinite::ComputeIntersections()
     // Now determine the start and end spline corner points for each spline
     ResizeAndFill2DVector(m_splineGroupIndexAndFromToIntersections, numSplines, 3, true, static_cast<UInt>(0));
 
+    for (UInt i = 0; i < m_splineIntersectionRatios.size(); ++i)
+    {
+        for (UInt j = 0; j < m_splineIntersectionRatios[i].size(); ++j)
+        {
+            std::cout << "  m_splineIntersectionRatios[" << i << "][" << j << "] " << m_splineIntersectionRatios[i][j] << std::endl;
+        }
+
+        std::cout << std::endl;
+    }
+
     // m_n direction
     for (UInt i = 0; i < m_numMSplines; i++)
     {
@@ -431,15 +511,28 @@ void CurvilinearGridFromSplinesTransfinite::ComputeIntersections()
         {
             UInt maxIndex = 0;
             UInt lastIndex = 0;
+            bool isAssigned = false;
             for (UInt k = 0; k <= i; k++)
             {
+
+                std::cout << " m_splineIntersectionRatios[j][k] " << m_splineIntersectionRatios[j][k] << std::endl;
+
                 if (std::abs(m_splineIntersectionRatios[j][k]) > 0.0)
                 {
+                    // maxIndex = std::max(maxIndex, m_splineGroupIndexAndFromToIntersections[lastIndex][0] + 1);
                     maxIndex = m_splineGroupIndexAndFromToIntersections[lastIndex][0] + 1;
                     lastIndex = k;
+                    isAssigned = true;
                 }
             }
+
+            if (!isAssigned)
+            {
+                std::cout << " not assigned " << i << "  " << j << std::endl;
+            }
+
             m_splineGroupIndexAndFromToIntersections[j][1] = maxIndex;
+            std::cout << " m_splineGroupIndexAndFromToIntersections j = " << j << " 1 = " << maxIndex << std::endl;
         }
         UInt maxIndex = 0;
         for (auto j = m_numMSplines; j < numSplines; j++)
@@ -450,6 +543,7 @@ void CurvilinearGridFromSplinesTransfinite::ComputeIntersections()
             }
         }
         m_splineGroupIndexAndFromToIntersections[i][0] = maxIndex;
+        std::cout << " m_splineGroupIndexAndFromToIntersections i = " << i << " 0 = " << maxIndex << std::endl;
     }
 
     // m_m direction
@@ -459,15 +553,24 @@ void CurvilinearGridFromSplinesTransfinite::ComputeIntersections()
         {
             UInt maxIndex = 0;
             UInt lastIndex = m_numMSplines;
+            bool isAssigned = false;
             for (auto k = m_numMSplines; k <= i; k++)
             {
                 if (std::abs(m_splineIntersectionRatios[j][k]) > 0.0)
                 {
+                    // maxIndex = std::max(maxIndex, m_splineGroupIndexAndFromToIntersections[lastIndex][0] + 1);
                     maxIndex = m_splineGroupIndexAndFromToIntersections[lastIndex][0] + 1;
                     lastIndex = k;
+                    isAssigned = true;
                 }
             }
+
+            if (!isAssigned)
+            {
+                std::cout << " not assigned " << std::endl;
+            }
             m_splineGroupIndexAndFromToIntersections[j][2] = maxIndex;
+            std::cout << " m_splineGroupIndexAndFromToIntersections j = " << j << " 2 = " << maxIndex << std::endl;
         }
         UInt maxIndex = 0;
         for (UInt j = 0; j < m_numMSplines; j++)
@@ -478,12 +581,14 @@ void CurvilinearGridFromSplinesTransfinite::ComputeIntersections()
             }
         }
         m_splineGroupIndexAndFromToIntersections[i][0] = maxIndex;
+        std::cout << " m_splineGroupIndexAndFromToIntersections i = " << i << " 0 = " << maxIndex << std::endl;
     }
 
     for (UInt i = 0; i < numSplines; i++)
     {
         m_splineGroupIndexAndFromToIntersections[i][1] = 0;
         m_splineGroupIndexAndFromToIntersections[i][2] = 0;
+        std::cout << " m_splineGroupIndexAndFromToIntersections i = " << i << " 1, 2a = " << 0 << std::endl;
     }
 
     // m_n constant, spline start end end
@@ -498,6 +603,8 @@ void CurvilinearGridFromSplinesTransfinite::ComputeIntersections()
                     m_splineGroupIndexAndFromToIntersections[i][1] = m_splineGroupIndexAndFromToIntersections[j][0];
                 }
                 m_splineGroupIndexAndFromToIntersections[i][2] = m_splineGroupIndexAndFromToIntersections[j][0];
+
+                std::cout << " m_splineGroupIndexAndFromToIntersections i = " << i << " 2b = " << m_splineGroupIndexAndFromToIntersections[j][0] << std::endl;
             }
         }
     }
@@ -514,9 +621,23 @@ void CurvilinearGridFromSplinesTransfinite::ComputeIntersections()
                     m_splineGroupIndexAndFromToIntersections[i][1] = m_splineGroupIndexAndFromToIntersections[j][0];
                 }
                 m_splineGroupIndexAndFromToIntersections[i][2] = m_splineGroupIndexAndFromToIntersections[j][0];
+                std::cout << " m_splineGroupIndexAndFromToIntersections i = " << i << " 2c = " << m_splineGroupIndexAndFromToIntersections[j][0] << std::endl;
             }
         }
     }
+    std::cout << std::endl;
+    std::cout << "--------------------------------" << std::endl;
+
+    for (UInt i = 0; i < m_splineGroupIndexAndFromToIntersections.size(); ++i)
+    {
+        for (UInt j = 0; j < m_splineGroupIndexAndFromToIntersections[i].size(); ++j)
+        {
+            std::cout << "m_splineGroupIndexAndFromToIntersections " << i << ", " << j << " = " << m_splineGroupIndexAndFromToIntersections[i][j] << std::endl;
+        }
+    }
+
+    std::cout << std::endl;
+    std::cout << std::endl;
 }
 
 bool CurvilinearGridFromSplinesTransfinite::OrderSplines(UInt startFirst,
@@ -543,6 +664,8 @@ bool CurvilinearGridFromSplinesTransfinite::OrderSplines(UInt startFirst,
                 {
                     continue;
                 }
+
+                std::cout << "swapping splines: " << j << "  " << k << std::endl;
 
                 // they must be swapped
                 m_splines->m_splineNodes[j].swap(m_splines->m_splineNodes[k]);

--- a/libs/MeshKernel/src/Polygon.cpp
+++ b/libs/MeshKernel/src/Polygon.cpp
@@ -311,7 +311,7 @@ std::vector<meshkernel::Point> meshkernel::Polygon::Refine(const size_t startInd
     const auto from = std::next(m_nodes.begin(), iStart);
     const auto to = std::next(m_nodes.begin(), iEnd);
 
-    auto computeDistance = [&projection = std::as_const(m_projection)](auto l, auto p)
+    auto computeDistance = [&projection = std::as_const(m_projection)](auto l, const Point& p)
     {
         return l + ComputeDistance(p, *std::next(&p), projection);
     };

--- a/libs/MeshKernel/src/Splines.cpp
+++ b/libs/MeshKernel/src/Splines.cpp
@@ -72,11 +72,13 @@ void Splines::AddSpline(const std::vector<Point>& splines, UInt start, UInt size
     // copy the spline nodes from start to start + size
     UInt count = 0;
     std::vector<Point> splinesNodes(size);
+
     for (auto i = start; i < start + size; ++i)
     {
         splinesNodes[count] = splines[i];
         count++;
     }
+
     m_splineNodes.emplace_back(splinesNodes);
 
     // compute second order derivatives
@@ -334,12 +336,14 @@ double Splines::ComputeSplineLength(UInt index,
     {
         const double leftPointCoordinateOnSpline = rightPointCoordinateOnSpline;
         rightPointCoordinateOnSpline += delta;
+
         if (rightPointCoordinateOnSpline > endAdimensionalCoordinate)
         {
             rightPointCoordinateOnSpline = endAdimensionalCoordinate;
         }
 
         const auto rightPoint = ComputePointOnSplineAtAdimensionalDistance(m_splineNodes[index], m_splineDerivatives[index], rightPointCoordinateOnSpline);
+
         if (!rightPoint.IsValid())
         {
             continue;

--- a/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
+++ b/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
@@ -274,7 +274,7 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongFirstS
 
     const auto curvilinearGrid = curvilinearGridFromSplinesTransfinite.Compute();
 
-    ASSERT_EQ(curvilinearGrid.m_nodes.size (), expectedPoints.size ());
+    ASSERT_EQ(curvilinearGrid.m_nodes.size(), expectedPoints.size());
 
     constexpr double tolerance = 1e-4;
 
@@ -283,7 +283,6 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongFirstS
         EXPECT_NEAR(expectedPoints[i].x, curvilinearGrid.m_nodes[i].x, tolerance);
         EXPECT_NEAR(expectedPoints[i].y, curvilinearGrid.m_nodes[i].y, tolerance);
     }
-
 }
 
 TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecondSpline)
@@ -309,7 +308,7 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecond
 
     const auto curvilinearGrid = curvilinearGridFromSplinesTransfinite.Compute();
 
-    ASSERT_EQ(curvilinearGrid.m_nodes.size (), expectedPoints.size ());
+    ASSERT_EQ(curvilinearGrid.m_nodes.size(), expectedPoints.size());
 
     constexpr double tolerance = 1e-4;
 
@@ -318,5 +317,4 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecond
         EXPECT_NEAR(expectedPoints[i].x, curvilinearGrid.m_nodes[i].x, tolerance);
         EXPECT_NEAR(expectedPoints[i].y, curvilinearGrid.m_nodes[i].y, tolerance);
     }
-
 }

--- a/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
+++ b/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
@@ -298,18 +298,6 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongFirstS
     testmk::TestCurvilinearGridFromSplines(firstSpline, secondSpline, thirdSpline, fourthSpline, expectedPoints);
 }
 
-TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleShortFirstSpline)
-{
-    std::vector<Point> firstSpline{{0.0, 2.0}, {1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
-    std::vector<Point> secondSpline{{1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}, {5.0, 0.0}};
-    std::vector<Point> thirdSpline{{2.5, -4.0}, {2.5, 4.0}};
-    std::vector<Point> fourthSpline{{4.5, 4.0}, {4.5, -4.0}};
-
-    std::vector<Point> expectedPoints{{4.5, 0.0}, {4.0, 0.0}, {3.5, 0.0}, {3.0, 0.0}, {2.5, 0.0}, {4.5, 0.5}, {4.0, 0.5}, {3.5, 0.5}, {3.0, 0.5}, {2.5, 0.5}, {4.5, 1.0}, {4.0, 1.0}, {3.5, 1.0}, {3.0, 1.0}, {2.5, 1.0}, {4.5, 1.5}, {4.0, 1.5}, {3.5, 1.5}, {3.0, 1.5}, {2.5, 1.5}, {4.5, 2.0}, {4.0, 2.0}, {3.5, 2.0}, {3.0, 2.0}, {2.5, 2.0}};
-    SCOPED_TRACE("FourSplinesSimpleRectangleShortFirstSpline");
-    testmk::TestCurvilinearGridFromSplines(thirdSpline, firstSpline, secondSpline, fourthSpline, expectedPoints);
-}
-
 TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecondSpline)
 {
     std::vector<Point> firstSpline{{1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
@@ -321,4 +309,30 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecond
 
     SCOPED_TRACE("FourSplinesSimpleRectangleLongSecondSpline");
     testmk::TestCurvilinearGridFromSplines(firstSpline, secondSpline, thirdSpline, fourthSpline, expectedPoints);
+}
+
+TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleShortFirstSpline)
+{
+    std::vector<Point> firstSpline{{0.0, 2.0}, {1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
+    std::vector<Point> secondSpline{{1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}, {5.0, 0.0}};
+    std::vector<Point> thirdSpline{{2.5, -4.0}, {2.5, 4.0}};
+    std::vector<Point> fourthSpline{{4.5, 4.0}, {4.5, -4.0}};
+
+    std::vector<Point> expectedPoints{{4.5, 0.0}, {4.0, 0.0}, {3.5, 0.0}, {3.0, 0.0}, {2.5, 0.0}, {4.5, 0.5}, {4.0, 0.5}, {3.5, 0.5}, {3.0, 0.5}, {2.5, 0.5}, {4.5, 1.0}, {4.0, 1.0}, {3.5, 1.0}, {3.0, 1.0}, {2.5, 1.0}, {4.5, 1.5}, {4.0, 1.5}, {3.5, 1.5}, {3.0, 1.5}, {2.5, 1.5}, {4.5, 2.0}, {4.0, 2.0}, {3.5, 2.0}, {3.0, 2.0}, {2.5, 2.0}};
+
+    SCOPED_TRACE("FourSplinesSimpleRectangleShortFirstSpline");
+    testmk::TestCurvilinearGridFromSplines(thirdSpline, firstSpline, secondSpline, fourthSpline, expectedPoints);
+}
+
+TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleShortSecondSpline)
+{
+    std::vector<Point> firstSpline{{0.0, 2.0}, {1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
+    std::vector<Point> secondSpline{{1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}, {5.0, 0.0}};
+    std::vector<Point> thirdSpline{{2.5, -4.0}, {2.5, 4.0}};
+    std::vector<Point> fourthSpline{{4.5, 4.0}, {4.5, -4.0}};
+
+    std::vector<Point> expectedPoints{{2.5, 2.0}, {3.0, 2.0}, {3.5, 2.0}, {4.0, 2.0}, {4.5, 2.0}, {2.5, 1.5}, {3.0, 1.5}, {3.5, 1.5}, {4.0, 1.5}, {4.5, 1.5}, {2.5, 1.0}, {3.0, 1.0}, {3.5, 1.0}, {4.0, 1.0}, {4.5, 1.0}, {2.5, 0.5}, {3.0, 0.5}, {3.5, 0.5}, {4.0, 0.5}, {4.5, 0.5}, {2.5, 0.0}, {3.0, 0.0}, {3.5, 0.0}, {4.0, 0.0}, {4.5, 0.0}};
+
+    SCOPED_TRACE("FourSplinesSimpleRectangleShortFirstSpline");
+    testmk::TestCurvilinearGridFromSplines(fourthSpline, secondSpline, thirdSpline, firstSpline, expectedPoints);
 }

--- a/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
+++ b/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
@@ -250,3 +250,57 @@ TEST(CurvilinearGridFromSplinesTransfinite, FiveSplines)
     ASSERT_NEAR(71.609593896396262, curvilinearGrid.m_gridNodes(1, 9).y, tolerance);
     ASSERT_NEAR(76.904826220873304, curvilinearGrid.m_gridNodes(1, 10).y, tolerance);
 }
+
+TEST(CurvilinearGridFromSplinesTransfinite, BugTest)
+{
+
+    std::vector<Point> firstSpline{{0, 2.0000}, {1., 2.0}, {2., 2.0}, {3., 2.0}, {4.0, 2.0}, {5.0, 2.0000}};
+    std::vector<Point> secondSpline{{1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}, {5.0, 0.0000}};
+    std::vector<Point> thirdSpline{{2.5, -4}, {2.5, 4.0}};
+    std::vector<Point> fourthSpline{{4.5, 4}, {4.5, -4.0}};
+
+    // std::vector<Point> firstSpline{{0, 2.0000}, {1.2566, 2.0}, {2.5133, 2.0}, {3.7699, 2.0}, {5.0265, 2.0}, {6.2832, 2.0000}};
+    // std::vector<Point> secondSpline{{1.2566, 0.0}, {2.5133, 0.0}, {3.7699, 0.0}, {5.0265, 0.0}, {6.2832, 0.0000}};
+    // std::vector<Point> thirdSpline{{2.6, -4}, {2.6, 4.0}};
+    // std::vector<Point> fourthSpline{{5.7, 4}, {5.7, -4.0}};
+
+    // Generates "squeezed" last two columns of elements
+    // std::vector<Point> firstSpline{{1.2566, 2.0}, {2.5133, 2.0}, {3.7699, 2.0}, {5.0265, 2.0}, {6.2832, 2.0000}};
+    // std::vector<Point> secondSpline{{1.2566, 0.0}, {2.5133, 0.0}, {3.7699, 0.0}, {5.0265, 0.0}, {6.2832, 0.0000}};
+    // std::vector<Point> thirdSpline{{1.4, -4}, {1.4, 4.0}};
+    // std::vector<Point> fourthSpline{{5.7, 4}, {5.7, -4.0}};
+
+    // Generates twisted last few columns of elements
+    // std::vector<Point> firstSpline{{1.2566, 2.0}, {2.5133, 2.0}, {3.7699, 2.0}, {5.0265, 2.0}, {6.2832, 2.0000}};
+    // std::vector<Point> secondSpline{{0, 0}, {1.2566, 0.0}, {2.5133, 0.0}, {3.7699, 0.0}, {5.0265, 0.0}, {6.2832, 0.0000}};
+    // std::vector<Point> thirdSpline{{1.4, -4}, {1.4, 4.0}};
+    // std::vector<Point> fourthSpline{{5.7, 4}, {5.7, -4.0}};
+
+    // Generates twisted last few columns of elements
+    // std::vector<Point> firstSpline{{0, 2.0000}, {1.2566, 2.0}, {2.5133, 2.0}, {3.7699, 2.0}, {5.0265, 2.0}, {6.2832, 2.0000}};
+    // std::vector<Point> secondSpline{{0, 0}, {1.2566, 0.0}, {2.5133, 0.0}, {3.7699, 0.0}, {5.0265, 0.0}, {6.2832, 0.0000}};
+    // std::vector<Point> thirdSpline{{0.2, -4}, {0.2, 4.0}};
+    // std::vector<Point> fourthSpline{{5.7, 4}, {5.7, -4.0}};
+
+    // Generates twisted last few columns of elements
+    // std::vector<Point> firstSpline{{0, 2.0000}, {1.2566, 2.9511}, {2.5133, 2.5878}, {3.7699, 1.4122}, {5.0265, 1.0489}, {6.2832, 2.0000}};
+    // std::vector<Point> secondSpline{{0, 0}, {1.2566, 0.9511}, {2.5133, 0.5878}, {3.7699, -0.5878}, {5.0265, -0.9511}, {6.2832, -0.0000}};
+    // std::vector<Point> thirdSpline{{0.2, -4}, {0.2, 4.0}};
+    // std::vector<Point> fourthSpline{{5.7, 4}, {5.7, -4.0}};
+
+    auto splines = std::make_shared<Splines>(Projection::cartesian);
+
+    splines->AddSpline(firstSpline);
+    splines->AddSpline(secondSpline);
+    splines->AddSpline(thirdSpline);
+    splines->AddSpline(fourthSpline);
+
+    CurvilinearParameters curvilinearParameters;
+    curvilinearParameters.n_refinement = 2;
+    curvilinearParameters.m_refinement = 2;
+    CurvilinearGridFromSplinesTransfinite curvilinearGridFromSplinesTransfinite(splines, curvilinearParameters);
+
+    const auto curvilinearGrid = curvilinearGridFromSplinesTransfinite.Compute();
+
+    meshkernel::Print(curvilinearGrid.m_nodes, curvilinearGrid.m_edges);
+}

--- a/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
+++ b/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
@@ -295,10 +295,19 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongFirstS
     std::vector<Point> expectedPoints{{2.5, 0.0}, {2.5, 0.5}, {2.5, 1.0}, {2.5, 1.5}, {2.5, 2.0}, {3.0, 0.0}, {3.0, 0.5}, {3.0, 1.0}, {3.0, 1.5}, {3.0, 2.0}, {3.5, 0.0}, {3.5, 0.5}, {3.5, 1.0}, {3.5, 1.5}, {3.5, 2.0}, {4.0, 0.0}, {4.0, 0.5}, {4.0, 1.0}, {4.0, 1.5}, {4.0, 2.0}, {4.5, 0.0}, {4.5, 0.5}, {4.5, 1.0}, {4.5, 1.5}, {4.5, 2.0}};
 
     SCOPED_TRACE("FourSplinesSimpleRectangleLongFirstSpline");
-    // testmk::TestCurvilinearGridFromSplines(firstSpline, secondSpline, thirdSpline, fourthSpline, expectedPoints);
+    testmk::TestCurvilinearGridFromSplines(firstSpline, secondSpline, thirdSpline, fourthSpline, expectedPoints);
+}
 
+TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleShortFirstSpline)
+{
+    std::vector<Point> firstSpline{{0.0, 2.0}, {1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
+    std::vector<Point> secondSpline{{1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}, {5.0, 0.0}};
+    std::vector<Point> thirdSpline{{2.5, -4.0}, {2.5, 4.0}};
+    std::vector<Point> fourthSpline{{4.5, 4.0}, {4.5, -4.0}};
+
+    std::vector<Point> expectedPoints{{4.5, 0.0}, {4.0, 0.0}, {3.5, 0.0}, {3.0, 0.0}, {2.5, 0.0}, {4.5, 0.5}, {4.0, 0.5}, {3.5, 0.5}, {3.0, 0.5}, {2.5, 0.5}, {4.5, 1.0}, {4.0, 1.0}, {3.5, 1.0}, {3.0, 1.0}, {2.5, 1.0}, {4.5, 1.5}, {4.0, 1.5}, {3.5, 1.5}, {3.0, 1.5}, {2.5, 1.5}, {4.5, 2.0}, {4.0, 2.0}, {3.5, 2.0}, {3.0, 2.0}, {2.5, 2.0}};
+    SCOPED_TRACE("FourSplinesSimpleRectangleShortFirstSpline");
     testmk::TestCurvilinearGridFromSplines(thirdSpline, firstSpline, secondSpline, fourthSpline, expectedPoints);
-    // testmk::TestCurvilinearGridFromSplines(fourthSpline, secondSpline, thirdSpline, firstSpline, expectedPoints);
 }
 
 TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecondSpline)

--- a/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
+++ b/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
@@ -296,6 +296,11 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongFirstS
 
     SCOPED_TRACE("FourSplinesSimpleRectangleLongFirstSpline");
     testmk::TestCurvilinearGridFromSplines(firstSpline, secondSpline, thirdSpline, fourthSpline, expectedPoints);
+    // Not compiled in yet due to crash (will be another Jira item)
+#if 0
+    testmk::TestCurvilinearGridFromSplines(thirdSpline, firstSpline, secondSpline, fourthSpline, expectedPoints);
+    testmk::TestCurvilinearGridFromSplines(fourthSpline, secondSpline, thirdSpline, firstSpline, expectedPoints);
+#endif
 }
 
 TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecondSpline)

--- a/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
+++ b/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
@@ -253,16 +253,12 @@ TEST(CurvilinearGridFromSplinesTransfinite, FiveSplines)
 
 TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongFirstSpline)
 {
-    std::vector<Point> firstSpline {{0.0, 2.0}, {1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
-    std::vector<Point> secondSpline            {{1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}, {5.0, 0.0}};
-    std::vector<Point> thirdSpline {{2.5, -4.0}, {2.5,  4.0}};
-    std::vector<Point> fourthSpline{{4.5,  4.0}, {4.5, -4.0}};
+    std::vector<Point> firstSpline{{0.0, 2.0}, {1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
+    std::vector<Point> secondSpline{{1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}, {5.0, 0.0}};
+    std::vector<Point> thirdSpline {{2.5, -4.0}, {2.5, 4.0}};
+    std::vector<Point> fourthSpline{{4.5, 4.0}, {4.5, -4.0}};
 
-    std::vector<Point> expectedPoints{{2.5, 0.0},  {2.5, 0.5},  {2.5, 1.0},  {2.5, 1.5},  {2.5, 2.0},
-                                      {3.0, 0.0},  {3.0, 0.5},  {3.0, 1.0},  {3.0, 1.5},  {3.0, 2.0},
-                                      {3.5, 0.0},  {3.5, 0.5},  {3.5, 1.0},  {3.5, 1.5},  {3.5, 2.0},
-                                      {4.0, 0.0},  {4.0, 0.5},  {4.0, 1.0},  {4.0, 1.5},  {4.0, 2.0},
-                                      {4.5, 0.0},  {4.5, 0.5},  {4.5, 1.0},  {4.5, 1.5},  {4.5, 2.0}};
+    std::vector<Point> expectedPoints{{2.5, 0.0}, {2.5, 0.5}, {2.5, 1.0}, {2.5, 1.5}, {2.5, 2.0}, {3.0, 0.0}, {3.0, 0.5}, {3.0, 1.0}, {3.0, 1.5}, {3.0, 2.0}, {3.5, 0.0}, {3.5, 0.5}, {3.5, 1.0}, {3.5, 1.5}, {3.5, 2.0}, {4.0, 0.0}, {4.0, 0.5}, {4.0, 1.0}, {4.0, 1.5}, {4.0, 2.0}, {4.5, 0.0}, {4.5, 0.5}, {4.5, 1.0}, {4.5, 1.5}, {4.5, 2.0}};
 
     auto splines = std::make_shared<Splines>(Projection::cartesian);
 
@@ -292,16 +288,12 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongFirstS
 
 TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecondSpline)
 {
-    std::vector<Point> firstSpline {{1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
+    std::vector<Point> firstSpline{{1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
     std::vector<Point> secondSpline{{0.0, 0.0}, {1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}, {5.0, 0.0}};
-    std::vector<Point> thirdSpline {{2.5, -4.0}, {2.5,  4.0}};
-    std::vector<Point> fourthSpline{{4.5,  4.0}, {4.5, -4.0}};
+    std::vector<Point> thirdSpline {{2.5, -4.0}, {2.5, 4.0}};
+    std::vector<Point> fourthSpline{{4.5, 4.0}, {4.5, -4.0}};
 
-    std::vector<Point> expectedPoints{{2.5, 0.0},  {2.5, 0.5},  {2.5, 1.0},  {2.5, 1.5},  {2.5, 2.0},
-                                      {3.0, 0.0},  {3.0, 0.5},  {3.0, 1.0},  {3.0, 1.5},  {3.0, 2.0},
-                                      {3.5, 0.0},  {3.5, 0.5},  {3.5, 1.0},  {3.5, 1.5},  {3.5, 2.0},
-                                      {4.0, 0.0},  {4.0, 0.5},  {4.0, 1.0},  {4.0, 1.5},  {4.0, 2.0},
-                                      {4.5, 0.0},  {4.5, 0.5},  {4.5, 1.0},  {4.5, 1.5},  {4.5, 2.0}};
+    std::vector<Point> expectedPoints{{2.5, 0.0}, {2.5, 0.5}, {2.5, 1.0}, {2.5, 1.5}, {2.5, 2.0}, {3.0, 0.0}, {3.0, 0.5}, {3.0, 1.0}, {3.0, 1.5}, {3.0, 2.0}, {3.5, 0.0}, {3.5, 0.5}, {3.5, 1.0}, {3.5, 1.5}, {3.5, 2.0}, {4.0, 0.0}, {4.0, 0.5}, {4.0, 1.0}, {4.0, 1.5}, {4.0, 2.0}, {4.5, 0.0}, {4.5, 0.5}, {4.5, 1.0}, {4.5, 1.5}, {4.5, 2.0}};
 
     auto splines = std::make_shared<Splines>(Projection::cartesian);
 
@@ -317,14 +309,14 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecond
 
     const auto curvilinearGrid = curvilinearGridFromSplinesTransfinite.Compute();
 
-    ASSERT_EQ (curvilinearGrid.m_nodes.size (), expectedPoints.size ());
+    ASSERT_EQ(curvilinearGrid.m_nodes.size (), expectedPoints.size ());
 
     constexpr double tolerance = 1e-4;
 
     for (size_t i = 0; i < curvilinearGrid.m_nodes.size (); ++i)
     {
-        EXPECT_NEAR (expectedPoints[i].x, curvilinearGrid.m_nodes[i].x, tolerance);
-        EXPECT_NEAR (expectedPoints[i].y, curvilinearGrid.m_nodes[i].y, tolerance);
+        EXPECT_NEAR(expectedPoints[i].x, curvilinearGrid.m_nodes[i].x, tolerance);
+        EXPECT_NEAR(expectedPoints[i].y, curvilinearGrid.m_nodes[i].y, tolerance);
     }
 
 }

--- a/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
+++ b/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
@@ -295,12 +295,10 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongFirstS
     std::vector<Point> expectedPoints{{2.5, 0.0}, {2.5, 0.5}, {2.5, 1.0}, {2.5, 1.5}, {2.5, 2.0}, {3.0, 0.0}, {3.0, 0.5}, {3.0, 1.0}, {3.0, 1.5}, {3.0, 2.0}, {3.5, 0.0}, {3.5, 0.5}, {3.5, 1.0}, {3.5, 1.5}, {3.5, 2.0}, {4.0, 0.0}, {4.0, 0.5}, {4.0, 1.0}, {4.0, 1.5}, {4.0, 2.0}, {4.5, 0.0}, {4.5, 0.5}, {4.5, 1.0}, {4.5, 1.5}, {4.5, 2.0}};
 
     SCOPED_TRACE("FourSplinesSimpleRectangleLongFirstSpline");
-    testmk::TestCurvilinearGridFromSplines(firstSpline, secondSpline, thirdSpline, fourthSpline, expectedPoints);
-    // Not compiled in yet due to crash (will be another Jira item)
-#if 0
+    // testmk::TestCurvilinearGridFromSplines(firstSpline, secondSpline, thirdSpline, fourthSpline, expectedPoints);
+
     testmk::TestCurvilinearGridFromSplines(thirdSpline, firstSpline, secondSpline, fourthSpline, expectedPoints);
-    testmk::TestCurvilinearGridFromSplines(fourthSpline, secondSpline, thirdSpline, firstSpline, expectedPoints);
-#endif
+    // testmk::TestCurvilinearGridFromSplines(fourthSpline, secondSpline, thirdSpline, firstSpline, expectedPoints);
 }
 
 TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecondSpline)

--- a/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
+++ b/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
@@ -251,39 +251,36 @@ TEST(CurvilinearGridFromSplinesTransfinite, FiveSplines)
     ASSERT_NEAR(76.904826220873304, curvilinearGrid.m_gridNodes(1, 10).y, tolerance);
 }
 
-namespace testmk
+void TestCurvilinearGridFromSplines(const std::vector<meshkernel::Point>& firstSpline,
+                                    const std::vector<meshkernel::Point>& secondSpline,
+                                    const std::vector<meshkernel::Point>& thirdSpline,
+                                    const std::vector<meshkernel::Point>& fourthSpline,
+                                    const std::vector<meshkernel::Point>& expectedPoints)
 {
-    void TestCurvilinearGridFromSplines(const std::vector<meshkernel::Point>& firstSpline,
-                                        const std::vector<meshkernel::Point>& secondSpline,
-                                        const std::vector<meshkernel::Point>& thirdSpline,
-                                        const std::vector<meshkernel::Point>& fourthSpline,
-                                        const std::vector<meshkernel::Point>& expectedPoints)
+    auto splines = std::make_shared<Splines>(Projection::cartesian);
+
+    splines->AddSpline(firstSpline);
+    splines->AddSpline(secondSpline);
+    splines->AddSpline(thirdSpline);
+    splines->AddSpline(fourthSpline);
+
+    CurvilinearParameters curvilinearParameters;
+    curvilinearParameters.n_refinement = 4;
+    curvilinearParameters.m_refinement = 4;
+    CurvilinearGridFromSplinesTransfinite curvilinearGridFromSplinesTransfinite(splines, curvilinearParameters);
+
+    const auto curvilinearGrid = curvilinearGridFromSplinesTransfinite.Compute();
+
+    ASSERT_EQ(curvilinearGrid.m_nodes.size(), expectedPoints.size());
+
+    constexpr double tolerance = 1e-4;
+
+    for (size_t i = 0; i < curvilinearGrid.m_nodes.size(); ++i)
     {
-        auto splines = std::make_shared<Splines>(Projection::cartesian);
-
-        splines->AddSpline(firstSpline);
-        splines->AddSpline(secondSpline);
-        splines->AddSpline(thirdSpline);
-        splines->AddSpline(fourthSpline);
-
-        CurvilinearParameters curvilinearParameters;
-        curvilinearParameters.n_refinement = 4;
-        curvilinearParameters.m_refinement = 4;
-        CurvilinearGridFromSplinesTransfinite curvilinearGridFromSplinesTransfinite(splines, curvilinearParameters);
-
-        const auto curvilinearGrid = curvilinearGridFromSplinesTransfinite.Compute();
-
-        ASSERT_EQ(curvilinearGrid.m_nodes.size(), expectedPoints.size());
-
-        constexpr double tolerance = 1e-4;
-
-        for (size_t i = 0; i < curvilinearGrid.m_nodes.size(); ++i)
-        {
-            EXPECT_NEAR(expectedPoints[i].x, curvilinearGrid.m_nodes[i].x, tolerance);
-            EXPECT_NEAR(expectedPoints[i].y, curvilinearGrid.m_nodes[i].y, tolerance);
-        }
+        EXPECT_NEAR(expectedPoints[i].x, curvilinearGrid.m_nodes[i].x, tolerance);
+        EXPECT_NEAR(expectedPoints[i].y, curvilinearGrid.m_nodes[i].y, tolerance);
     }
-} // namespace testmk
+}
 
 TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongFirstSpline)
 {
@@ -295,7 +292,7 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongFirstS
     std::vector<Point> expectedPoints{{2.5, 0.0}, {2.5, 0.5}, {2.5, 1.0}, {2.5, 1.5}, {2.5, 2.0}, {3.0, 0.0}, {3.0, 0.5}, {3.0, 1.0}, {3.0, 1.5}, {3.0, 2.0}, {3.5, 0.0}, {3.5, 0.5}, {3.5, 1.0}, {3.5, 1.5}, {3.5, 2.0}, {4.0, 0.0}, {4.0, 0.5}, {4.0, 1.0}, {4.0, 1.5}, {4.0, 2.0}, {4.5, 0.0}, {4.5, 0.5}, {4.5, 1.0}, {4.5, 1.5}, {4.5, 2.0}};
 
     SCOPED_TRACE("FourSplinesSimpleRectangleLongFirstSpline");
-    testmk::TestCurvilinearGridFromSplines(firstSpline, secondSpline, thirdSpline, fourthSpline, expectedPoints);
+    TestCurvilinearGridFromSplines(firstSpline, secondSpline, thirdSpline, fourthSpline, expectedPoints);
 }
 
 TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecondSpline)
@@ -308,7 +305,7 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecond
     std::vector<Point> expectedPoints{{2.5, 0.0}, {2.5, 0.5}, {2.5, 1.0}, {2.5, 1.5}, {2.5, 2.0}, {3.0, 0.0}, {3.0, 0.5}, {3.0, 1.0}, {3.0, 1.5}, {3.0, 2.0}, {3.5, 0.0}, {3.5, 0.5}, {3.5, 1.0}, {3.5, 1.5}, {3.5, 2.0}, {4.0, 0.0}, {4.0, 0.5}, {4.0, 1.0}, {4.0, 1.5}, {4.0, 2.0}, {4.5, 0.0}, {4.5, 0.5}, {4.5, 1.0}, {4.5, 1.5}, {4.5, 2.0}};
 
     SCOPED_TRACE("FourSplinesSimpleRectangleLongSecondSpline");
-    testmk::TestCurvilinearGridFromSplines(firstSpline, secondSpline, thirdSpline, fourthSpline, expectedPoints);
+    TestCurvilinearGridFromSplines(firstSpline, secondSpline, thirdSpline, fourthSpline, expectedPoints);
 }
 
 TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleShortFirstSpline)
@@ -321,7 +318,7 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleShortFirst
     std::vector<Point> expectedPoints{{4.5, 0.0}, {4.0, 0.0}, {3.5, 0.0}, {3.0, 0.0}, {2.5, 0.0}, {4.5, 0.5}, {4.0, 0.5}, {3.5, 0.5}, {3.0, 0.5}, {2.5, 0.5}, {4.5, 1.0}, {4.0, 1.0}, {3.5, 1.0}, {3.0, 1.0}, {2.5, 1.0}, {4.5, 1.5}, {4.0, 1.5}, {3.5, 1.5}, {3.0, 1.5}, {2.5, 1.5}, {4.5, 2.0}, {4.0, 2.0}, {3.5, 2.0}, {3.0, 2.0}, {2.5, 2.0}};
 
     SCOPED_TRACE("FourSplinesSimpleRectangleShortFirstSpline");
-    testmk::TestCurvilinearGridFromSplines(thirdSpline, firstSpline, secondSpline, fourthSpline, expectedPoints);
+    TestCurvilinearGridFromSplines(thirdSpline, firstSpline, secondSpline, fourthSpline, expectedPoints);
 }
 
 TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleShortSecondSpline)
@@ -333,6 +330,6 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleShortSecon
 
     std::vector<Point> expectedPoints{{2.5, 2.0}, {3.0, 2.0}, {3.5, 2.0}, {4.0, 2.0}, {4.5, 2.0}, {2.5, 1.5}, {3.0, 1.5}, {3.5, 1.5}, {4.0, 1.5}, {4.5, 1.5}, {2.5, 1.0}, {3.0, 1.0}, {3.5, 1.0}, {4.0, 1.0}, {4.5, 1.0}, {2.5, 0.5}, {3.0, 0.5}, {3.5, 0.5}, {4.0, 0.5}, {4.5, 0.5}, {2.5, 0.0}, {3.0, 0.0}, {3.5, 0.0}, {4.0, 0.0}, {4.5, 0.0}};
 
-    SCOPED_TRACE("FourSplinesSimpleRectangleShortFirstSpline");
-    testmk::TestCurvilinearGridFromSplines(fourthSpline, secondSpline, thirdSpline, firstSpline, expectedPoints);
+    SCOPED_TRACE("FourSplinesSimpleRectangleShortSecondSpline");
+    TestCurvilinearGridFromSplines(fourthSpline, secondSpline, thirdSpline, firstSpline, expectedPoints);
 }

--- a/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
+++ b/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
@@ -255,42 +255,7 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongFirstS
 {
     std::vector<Point> firstSpline{{0.0, 2.0}, {1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
     std::vector<Point> secondSpline{{1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}, {5.0, 0.0}};
-    std::vector<Point> thirdSpline {{2.5, -4.0}, {2.5, 4.0}};
-    std::vector<Point> fourthSpline{{4.5, 4.0}, {4.5, -4.0}};
-
-    std::vector<Point> expectedPoints{{2.5, 0.0}, {2.5, 0.5}, {2.5, 1.0}, {2.5, 1.5}, {2.5, 2.0}, {3.0, 0.0}, {3.0, 0.5}, {3.0, 1.0}, {3.0, 1.5}, {3.0, 2.0}, {3.5, 0.0}, {3.5, 0.5}, {3.5, 1.0}, {3.5, 1.5}, {3.5, 2.0}, {4.0, 0.0}, {4.0, 0.5}, {4.0, 1.0}, {4.0, 1.5}, {4.0, 2.0}, {4.5, 0.0}, {4.5, 0.5}, {4.5, 1.0}, {4.5, 1.5}, {4.5, 2.0}};
-
-    auto splines = std::make_shared<Splines>(Projection::cartesian);
-
-    splines->AddSpline(firstSpline);
-    splines->AddSpline(secondSpline);
-    splines->AddSpline(thirdSpline);
-    splines->AddSpline(fourthSpline);
-
-    CurvilinearParameters curvilinearParameters;
-    curvilinearParameters.n_refinement = 4;
-    curvilinearParameters.m_refinement = 4;
-    CurvilinearGridFromSplinesTransfinite curvilinearGridFromSplinesTransfinite(splines, curvilinearParameters);
-
-    const auto curvilinearGrid = curvilinearGridFromSplinesTransfinite.Compute();
-
-    ASSERT_EQ (curvilinearGrid.m_nodes.size (), expectedPoints.size ());
-
-    constexpr double tolerance = 1e-4;
-
-    for (size_t i = 0; i < curvilinearGrid.m_nodes.size (); ++i)
-    {
-        EXPECT_NEAR (expectedPoints[i].x, curvilinearGrid.m_nodes[i].x, tolerance);
-        EXPECT_NEAR (expectedPoints[i].y, curvilinearGrid.m_nodes[i].y, tolerance);
-    }
-
-}
-
-TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecondSpline)
-{
-    std::vector<Point> firstSpline{{1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
-    std::vector<Point> secondSpline{{0.0, 0.0}, {1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}, {5.0, 0.0}};
-    std::vector<Point> thirdSpline {{2.5, -4.0}, {2.5, 4.0}};
+    std::vector<Point> thirdSpline{{2.5, -4.0}, {2.5, 4.0}};
     std::vector<Point> fourthSpline{{4.5, 4.0}, {4.5, -4.0}};
 
     std::vector<Point> expectedPoints{{2.5, 0.0}, {2.5, 0.5}, {2.5, 1.0}, {2.5, 1.5}, {2.5, 2.0}, {3.0, 0.0}, {3.0, 0.5}, {3.0, 1.0}, {3.0, 1.5}, {3.0, 2.0}, {3.5, 0.0}, {3.5, 0.5}, {3.5, 1.0}, {3.5, 1.5}, {3.5, 2.0}, {4.0, 0.0}, {4.0, 0.5}, {4.0, 1.0}, {4.0, 1.5}, {4.0, 2.0}, {4.5, 0.0}, {4.5, 0.5}, {4.5, 1.0}, {4.5, 1.5}, {4.5, 2.0}};
@@ -313,7 +278,42 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecond
 
     constexpr double tolerance = 1e-4;
 
-    for (size_t i = 0; i < curvilinearGrid.m_nodes.size (); ++i)
+    for (size_t i = 0; i < curvilinearGrid.m_nodes.size(); ++i)
+    {
+        EXPECT_NEAR(expectedPoints[i].x, curvilinearGrid.m_nodes[i].x, tolerance);
+        EXPECT_NEAR(expectedPoints[i].y, curvilinearGrid.m_nodes[i].y, tolerance);
+    }
+
+}
+
+TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecondSpline)
+{
+    std::vector<Point> firstSpline{{1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
+    std::vector<Point> secondSpline{{0.0, 0.0}, {1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}, {5.0, 0.0}};
+    std::vector<Point> thirdSpline{{2.5, -4.0}, {2.5, 4.0}};
+    std::vector<Point> fourthSpline{{4.5, 4.0}, {4.5, -4.0}};
+
+    std::vector<Point> expectedPoints{{2.5, 0.0}, {2.5, 0.5}, {2.5, 1.0}, {2.5, 1.5}, {2.5, 2.0}, {3.0, 0.0}, {3.0, 0.5}, {3.0, 1.0}, {3.0, 1.5}, {3.0, 2.0}, {3.5, 0.0}, {3.5, 0.5}, {3.5, 1.0}, {3.5, 1.5}, {3.5, 2.0}, {4.0, 0.0}, {4.0, 0.5}, {4.0, 1.0}, {4.0, 1.5}, {4.0, 2.0}, {4.5, 0.0}, {4.5, 0.5}, {4.5, 1.0}, {4.5, 1.5}, {4.5, 2.0}};
+
+    auto splines = std::make_shared<Splines>(Projection::cartesian);
+
+    splines->AddSpline(firstSpline);
+    splines->AddSpline(secondSpline);
+    splines->AddSpline(thirdSpline);
+    splines->AddSpline(fourthSpline);
+
+    CurvilinearParameters curvilinearParameters;
+    curvilinearParameters.n_refinement = 4;
+    curvilinearParameters.m_refinement = 4;
+    CurvilinearGridFromSplinesTransfinite curvilinearGridFromSplinesTransfinite(splines, curvilinearParameters);
+
+    const auto curvilinearGrid = curvilinearGridFromSplinesTransfinite.Compute();
+
+    ASSERT_EQ(curvilinearGrid.m_nodes.size (), expectedPoints.size ());
+
+    constexpr double tolerance = 1e-4;
+
+    for (size_t i = 0; i < curvilinearGrid.m_nodes.size(); ++i)
     {
         EXPECT_NEAR(expectedPoints[i].x, curvilinearGrid.m_nodes[i].x, tolerance);
         EXPECT_NEAR(expectedPoints[i].y, curvilinearGrid.m_nodes[i].y, tolerance);

--- a/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
+++ b/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
@@ -251,42 +251,18 @@ TEST(CurvilinearGridFromSplinesTransfinite, FiveSplines)
     ASSERT_NEAR(76.904826220873304, curvilinearGrid.m_gridNodes(1, 10).y, tolerance);
 }
 
-TEST(CurvilinearGridFromSplinesTransfinite, BugTest)
+TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongFirstSpline)
 {
+    std::vector<Point> firstSpline {{0.0, 2.0}, {1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
+    std::vector<Point> secondSpline            {{1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}, {5.0, 0.0}};
+    std::vector<Point> thirdSpline {{2.5, -4.0}, {2.5,  4.0}};
+    std::vector<Point> fourthSpline{{4.5,  4.0}, {4.5, -4.0}};
 
-    std::vector<Point> firstSpline{{0, 2.0000}, {1., 2.0}, {2., 2.0}, {3., 2.0}, {4.0, 2.0}, {5.0, 2.0000}};
-    std::vector<Point> secondSpline{{1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}, {5.0, 0.0000}};
-    std::vector<Point> thirdSpline{{2.5, -4}, {2.5, 4.0}};
-    std::vector<Point> fourthSpline{{4.5, 4}, {4.5, -4.0}};
-
-    // std::vector<Point> firstSpline{{0, 2.0000}, {1.2566, 2.0}, {2.5133, 2.0}, {3.7699, 2.0}, {5.0265, 2.0}, {6.2832, 2.0000}};
-    // std::vector<Point> secondSpline{{1.2566, 0.0}, {2.5133, 0.0}, {3.7699, 0.0}, {5.0265, 0.0}, {6.2832, 0.0000}};
-    // std::vector<Point> thirdSpline{{2.6, -4}, {2.6, 4.0}};
-    // std::vector<Point> fourthSpline{{5.7, 4}, {5.7, -4.0}};
-
-    // Generates "squeezed" last two columns of elements
-    // std::vector<Point> firstSpline{{1.2566, 2.0}, {2.5133, 2.0}, {3.7699, 2.0}, {5.0265, 2.0}, {6.2832, 2.0000}};
-    // std::vector<Point> secondSpline{{1.2566, 0.0}, {2.5133, 0.0}, {3.7699, 0.0}, {5.0265, 0.0}, {6.2832, 0.0000}};
-    // std::vector<Point> thirdSpline{{1.4, -4}, {1.4, 4.0}};
-    // std::vector<Point> fourthSpline{{5.7, 4}, {5.7, -4.0}};
-
-    // Generates twisted last few columns of elements
-    // std::vector<Point> firstSpline{{1.2566, 2.0}, {2.5133, 2.0}, {3.7699, 2.0}, {5.0265, 2.0}, {6.2832, 2.0000}};
-    // std::vector<Point> secondSpline{{0, 0}, {1.2566, 0.0}, {2.5133, 0.0}, {3.7699, 0.0}, {5.0265, 0.0}, {6.2832, 0.0000}};
-    // std::vector<Point> thirdSpline{{1.4, -4}, {1.4, 4.0}};
-    // std::vector<Point> fourthSpline{{5.7, 4}, {5.7, -4.0}};
-
-    // Generates twisted last few columns of elements
-    // std::vector<Point> firstSpline{{0, 2.0000}, {1.2566, 2.0}, {2.5133, 2.0}, {3.7699, 2.0}, {5.0265, 2.0}, {6.2832, 2.0000}};
-    // std::vector<Point> secondSpline{{0, 0}, {1.2566, 0.0}, {2.5133, 0.0}, {3.7699, 0.0}, {5.0265, 0.0}, {6.2832, 0.0000}};
-    // std::vector<Point> thirdSpline{{0.2, -4}, {0.2, 4.0}};
-    // std::vector<Point> fourthSpline{{5.7, 4}, {5.7, -4.0}};
-
-    // Generates twisted last few columns of elements
-    // std::vector<Point> firstSpline{{0, 2.0000}, {1.2566, 2.9511}, {2.5133, 2.5878}, {3.7699, 1.4122}, {5.0265, 1.0489}, {6.2832, 2.0000}};
-    // std::vector<Point> secondSpline{{0, 0}, {1.2566, 0.9511}, {2.5133, 0.5878}, {3.7699, -0.5878}, {5.0265, -0.9511}, {6.2832, -0.0000}};
-    // std::vector<Point> thirdSpline{{0.2, -4}, {0.2, 4.0}};
-    // std::vector<Point> fourthSpline{{5.7, 4}, {5.7, -4.0}};
+    std::vector<Point> expectedPoints{{2.5, 0.0},  {2.5, 0.5},  {2.5, 1.0},  {2.5, 1.5},  {2.5, 2.0},
+                                      {3.0, 0.0},  {3.0, 0.5},  {3.0, 1.0},  {3.0, 1.5},  {3.0, 2.0},
+                                      {3.5, 0.0},  {3.5, 0.5},  {3.5, 1.0},  {3.5, 1.5},  {3.5, 2.0},
+                                      {4.0, 0.0},  {4.0, 0.5},  {4.0, 1.0},  {4.0, 1.5},  {4.0, 2.0},
+                                      {4.5, 0.0},  {4.5, 0.5},  {4.5, 1.0},  {4.5, 1.5},  {4.5, 2.0}};
 
     auto splines = std::make_shared<Splines>(Projection::cartesian);
 
@@ -296,11 +272,59 @@ TEST(CurvilinearGridFromSplinesTransfinite, BugTest)
     splines->AddSpline(fourthSpline);
 
     CurvilinearParameters curvilinearParameters;
-    curvilinearParameters.n_refinement = 2;
-    curvilinearParameters.m_refinement = 2;
+    curvilinearParameters.n_refinement = 4;
+    curvilinearParameters.m_refinement = 4;
     CurvilinearGridFromSplinesTransfinite curvilinearGridFromSplinesTransfinite(splines, curvilinearParameters);
 
     const auto curvilinearGrid = curvilinearGridFromSplinesTransfinite.Compute();
 
-    meshkernel::Print(curvilinearGrid.m_nodes, curvilinearGrid.m_edges);
+    ASSERT_EQ (curvilinearGrid.m_nodes.size (), expectedPoints.size ());
+
+    constexpr double tolerance = 1e-4;
+
+    for (size_t i = 0; i < curvilinearGrid.m_nodes.size (); ++i)
+    {
+        EXPECT_NEAR (expectedPoints[i].x, curvilinearGrid.m_nodes[i].x, tolerance);
+        EXPECT_NEAR (expectedPoints[i].y, curvilinearGrid.m_nodes[i].y, tolerance);
+    }
+
+}
+
+TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecondSpline)
+{
+    std::vector<Point> firstSpline {{1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
+    std::vector<Point> secondSpline{{0.0, 0.0}, {1.0, 0.0}, {2.0, 0.0}, {3.0, 0.0}, {4.0, 0.0}, {5.0, 0.0}};
+    std::vector<Point> thirdSpline {{2.5, -4.0}, {2.5,  4.0}};
+    std::vector<Point> fourthSpline{{4.5,  4.0}, {4.5, -4.0}};
+
+    std::vector<Point> expectedPoints{{2.5, 0.0},  {2.5, 0.5},  {2.5, 1.0},  {2.5, 1.5},  {2.5, 2.0},
+                                      {3.0, 0.0},  {3.0, 0.5},  {3.0, 1.0},  {3.0, 1.5},  {3.0, 2.0},
+                                      {3.5, 0.0},  {3.5, 0.5},  {3.5, 1.0},  {3.5, 1.5},  {3.5, 2.0},
+                                      {4.0, 0.0},  {4.0, 0.5},  {4.0, 1.0},  {4.0, 1.5},  {4.0, 2.0},
+                                      {4.5, 0.0},  {4.5, 0.5},  {4.5, 1.0},  {4.5, 1.5},  {4.5, 2.0}};
+
+    auto splines = std::make_shared<Splines>(Projection::cartesian);
+
+    splines->AddSpline(firstSpline);
+    splines->AddSpline(secondSpline);
+    splines->AddSpline(thirdSpline);
+    splines->AddSpline(fourthSpline);
+
+    CurvilinearParameters curvilinearParameters;
+    curvilinearParameters.n_refinement = 4;
+    curvilinearParameters.m_refinement = 4;
+    CurvilinearGridFromSplinesTransfinite curvilinearGridFromSplinesTransfinite(splines, curvilinearParameters);
+
+    const auto curvilinearGrid = curvilinearGridFromSplinesTransfinite.Compute();
+
+    ASSERT_EQ (curvilinearGrid.m_nodes.size (), expectedPoints.size ());
+
+    constexpr double tolerance = 1e-4;
+
+    for (size_t i = 0; i < curvilinearGrid.m_nodes.size (); ++i)
+    {
+        EXPECT_NEAR (expectedPoints[i].x, curvilinearGrid.m_nodes[i].x, tolerance);
+        EXPECT_NEAR (expectedPoints[i].y, curvilinearGrid.m_nodes[i].y, tolerance);
+    }
+
 }

--- a/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
+++ b/libs/MeshKernel/tests/src/CurvilinearGridFromSplinesTransfiniteTests.cpp
@@ -251,6 +251,40 @@ TEST(CurvilinearGridFromSplinesTransfinite, FiveSplines)
     ASSERT_NEAR(76.904826220873304, curvilinearGrid.m_gridNodes(1, 10).y, tolerance);
 }
 
+namespace testmk
+{
+    void TestCurvilinearGridFromSplines(const std::vector<meshkernel::Point>& firstSpline,
+                                        const std::vector<meshkernel::Point>& secondSpline,
+                                        const std::vector<meshkernel::Point>& thirdSpline,
+                                        const std::vector<meshkernel::Point>& fourthSpline,
+                                        const std::vector<meshkernel::Point>& expectedPoints)
+    {
+        auto splines = std::make_shared<Splines>(Projection::cartesian);
+
+        splines->AddSpline(firstSpline);
+        splines->AddSpline(secondSpline);
+        splines->AddSpline(thirdSpline);
+        splines->AddSpline(fourthSpline);
+
+        CurvilinearParameters curvilinearParameters;
+        curvilinearParameters.n_refinement = 4;
+        curvilinearParameters.m_refinement = 4;
+        CurvilinearGridFromSplinesTransfinite curvilinearGridFromSplinesTransfinite(splines, curvilinearParameters);
+
+        const auto curvilinearGrid = curvilinearGridFromSplinesTransfinite.Compute();
+
+        ASSERT_EQ(curvilinearGrid.m_nodes.size(), expectedPoints.size());
+
+        constexpr double tolerance = 1e-4;
+
+        for (size_t i = 0; i < curvilinearGrid.m_nodes.size(); ++i)
+        {
+            EXPECT_NEAR(expectedPoints[i].x, curvilinearGrid.m_nodes[i].x, tolerance);
+            EXPECT_NEAR(expectedPoints[i].y, curvilinearGrid.m_nodes[i].y, tolerance);
+        }
+    }
+} // namespace testmk
+
 TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongFirstSpline)
 {
     std::vector<Point> firstSpline{{0.0, 2.0}, {1.0, 2.0}, {2.0, 2.0}, {3.0, 2.0}, {4.0, 2.0}, {5.0, 2.0}};
@@ -260,29 +294,8 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongFirstS
 
     std::vector<Point> expectedPoints{{2.5, 0.0}, {2.5, 0.5}, {2.5, 1.0}, {2.5, 1.5}, {2.5, 2.0}, {3.0, 0.0}, {3.0, 0.5}, {3.0, 1.0}, {3.0, 1.5}, {3.0, 2.0}, {3.5, 0.0}, {3.5, 0.5}, {3.5, 1.0}, {3.5, 1.5}, {3.5, 2.0}, {4.0, 0.0}, {4.0, 0.5}, {4.0, 1.0}, {4.0, 1.5}, {4.0, 2.0}, {4.5, 0.0}, {4.5, 0.5}, {4.5, 1.0}, {4.5, 1.5}, {4.5, 2.0}};
 
-    auto splines = std::make_shared<Splines>(Projection::cartesian);
-
-    splines->AddSpline(firstSpline);
-    splines->AddSpline(secondSpline);
-    splines->AddSpline(thirdSpline);
-    splines->AddSpline(fourthSpline);
-
-    CurvilinearParameters curvilinearParameters;
-    curvilinearParameters.n_refinement = 4;
-    curvilinearParameters.m_refinement = 4;
-    CurvilinearGridFromSplinesTransfinite curvilinearGridFromSplinesTransfinite(splines, curvilinearParameters);
-
-    const auto curvilinearGrid = curvilinearGridFromSplinesTransfinite.Compute();
-
-    ASSERT_EQ(curvilinearGrid.m_nodes.size(), expectedPoints.size());
-
-    constexpr double tolerance = 1e-4;
-
-    for (size_t i = 0; i < curvilinearGrid.m_nodes.size(); ++i)
-    {
-        EXPECT_NEAR(expectedPoints[i].x, curvilinearGrid.m_nodes[i].x, tolerance);
-        EXPECT_NEAR(expectedPoints[i].y, curvilinearGrid.m_nodes[i].y, tolerance);
-    }
+    SCOPED_TRACE("FourSplinesSimpleRectangleLongFirstSpline");
+    testmk::TestCurvilinearGridFromSplines(firstSpline, secondSpline, thirdSpline, fourthSpline, expectedPoints);
 }
 
 TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecondSpline)
@@ -294,27 +307,6 @@ TEST(CurvilinearGridFromSplinesTransfinite, FourSplinesSimpleRectangleLongSecond
 
     std::vector<Point> expectedPoints{{2.5, 0.0}, {2.5, 0.5}, {2.5, 1.0}, {2.5, 1.5}, {2.5, 2.0}, {3.0, 0.0}, {3.0, 0.5}, {3.0, 1.0}, {3.0, 1.5}, {3.0, 2.0}, {3.5, 0.0}, {3.5, 0.5}, {3.5, 1.0}, {3.5, 1.5}, {3.5, 2.0}, {4.0, 0.0}, {4.0, 0.5}, {4.0, 1.0}, {4.0, 1.5}, {4.0, 2.0}, {4.5, 0.0}, {4.5, 0.5}, {4.5, 1.0}, {4.5, 1.5}, {4.5, 2.0}};
 
-    auto splines = std::make_shared<Splines>(Projection::cartesian);
-
-    splines->AddSpline(firstSpline);
-    splines->AddSpline(secondSpline);
-    splines->AddSpline(thirdSpline);
-    splines->AddSpline(fourthSpline);
-
-    CurvilinearParameters curvilinearParameters;
-    curvilinearParameters.n_refinement = 4;
-    curvilinearParameters.m_refinement = 4;
-    CurvilinearGridFromSplinesTransfinite curvilinearGridFromSplinesTransfinite(splines, curvilinearParameters);
-
-    const auto curvilinearGrid = curvilinearGridFromSplinesTransfinite.Compute();
-
-    ASSERT_EQ(curvilinearGrid.m_nodes.size(), expectedPoints.size());
-
-    constexpr double tolerance = 1e-4;
-
-    for (size_t i = 0; i < curvilinearGrid.m_nodes.size(); ++i)
-    {
-        EXPECT_NEAR(expectedPoints[i].x, curvilinearGrid.m_nodes[i].x, tolerance);
-        EXPECT_NEAR(expectedPoints[i].y, curvilinearGrid.m_nodes[i].y, tolerance);
-    }
+    SCOPED_TRACE("FourSplinesSimpleRectangleLongSecondSpline");
+    testmk::TestCurvilinearGridFromSplines(firstSpline, secondSpline, thirdSpline, fourthSpline, expectedPoints);
 }


### PR DESCRIPTION
The bug fix was to add an additional spline ordering before the original order and setting of the m_numMSplines and m_numNSplines.