### PR TITLE
Release v5.0.1 (manual)

### DIFF
--- a/.github/workflows/build-and-test-workflow.yml
+++ b/.github/workflows/build-and-test-workflow.yml
@@ -50,14 +50,13 @@ jobs:
       - name: Install system-provided dependencies
         run: |
           if [ "${{ runner.os }}" == "macOS" ]; then
-            brew install boost doxygen netcdf
+            brew install boost doxygen
           elif [ "${{ runner.os }}" == "Linux" ]; then
             sudo apt-get install libboost-all-dev doxygen
           fi
 
       # Step: Restore cached user-provided dependencies
-      - if: runner.os != 'macOS'
-        name: Restore cached user-provided dependencies
+      - name: Restore cached user-provided dependencies
         uses: actions/cache/restore@v3
         id: restore-cached-external-dependencies
         with:
@@ -67,7 +66,7 @@ jobs:
 
       # Step: Build and install user-provided dependencies, executes only if no cache restored
       - name: Build and install user-provided dependencies
-        if: runner.os != 'macOS' && steps.restore-cached-external-dependencies.outputs.cache-hit != 'true'
+        if: steps.restore-cached-external-dependencies.outputs.cache-hit != 'true'
         # NetCDF Dependencies m4, curl, and openssl are provided by the build machine
         run: >
           pwsh ${{ github.workspace }}/scripts/install_netcdf_static.ps1
@@ -79,7 +78,7 @@ jobs:
       # Step: Cache user-provided dependencies, executes only if no cache restored
       - name: Cache user-provided dependencies
         uses: actions/cache/save@v3
-        if: runner.os != 'macOS' && steps.restore-cached-external-dependencies.outputs.cache-hit != 'true'
+        if: steps.restore-cached-external-dependencies.outputs.cache-hit != 'true'
         with:
           key: ${{ inputs.platform }}-${{ inputs.build_type }}-cache-key
           path: ${{ steps.paths.outputs.ext_deps_dir }}/netcdf-c/install/netcdf-c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23)
 
-set(MESHKERNEL_VERSION 5.0.0)
+set(MESHKERNEL_VERSION 5.0.1)
 
 project(
   MeshKernel

--- a/libs/MeshKernel/src/Mesh2D.cpp
+++ b/libs/MeshKernel/src/Mesh2D.cpp
@@ -1744,7 +1744,7 @@ std::unique_ptr<meshkernel::UndoAction> Mesh2D::DeleteMesh(const Polygons& polyg
     else if (deletionOption == InsideNotIntersected && invertDeletion)
     {
         excludedFace = [&isFaceCompletlyIncludedInPolygon, &faceIntersections](UInt f)
-        { return isFaceCompletlyIncludedInPolygon[f] || faceIntersections[f].faceIndex != constants::missing::uintValue; };
+        { return isFaceCompletlyIncludedInPolygon[f] && faceIntersections[f].faceIndex == constants::missing::uintValue; };
     }
     else if (deletionOption == InsideAndIntersected && !invertDeletion)
     {
@@ -1754,7 +1754,7 @@ std::unique_ptr<meshkernel::UndoAction> Mesh2D::DeleteMesh(const Polygons& polyg
     else if (deletionOption == InsideAndIntersected && invertDeletion)
     {
         excludedFace = [&isFaceCompletlyIncludedInPolygon, &faceIntersections](UInt f)
-        { return isFaceCompletlyIncludedInPolygon[f] && faceIntersections[f].faceIndex == constants::missing::uintValue; };
+        { return isFaceCompletlyIncludedInPolygon[f] || faceIntersections[f].faceIndex != constants::missing::uintValue; };
     }
 
     // Mark edges for deletion

--- a/libs/MeshKernel/tests/src/MeshTests.cpp
+++ b/libs/MeshKernel/tests/src/MeshTests.cpp
@@ -716,8 +716,8 @@ public:
         return {
             {meshkernel::Mesh2D::DeleteMeshOptions::InsideNotIntersected, false, 16},
             {meshkernel::Mesh2D::DeleteMeshOptions::InsideAndIntersected, false, 14},
-            {meshkernel::Mesh2D::DeleteMeshOptions::InsideNotIntersected, true, 6},
-            {meshkernel::Mesh2D::DeleteMeshOptions::InsideAndIntersected, true, 0}
+            {meshkernel::Mesh2D::DeleteMeshOptions::InsideNotIntersected, true, 0},
+            {meshkernel::Mesh2D::DeleteMeshOptions::InsideAndIntersected, true, 6}
 
         };
     }
@@ -747,8 +747,7 @@ TEST_P(MeshDeletion, expected_results)
     auto undoAction = mesh->DeleteMesh(polygon, deleteOption, invertSelection);
 
     // Assert
-    const auto numValidNodes = mesh->GetNumValidNodes();
-    ASSERT_EQ(numNodes, numValidNodes);
+    ASSERT_EQ(numNodes, mesh->GetNumValidNodes());
 
     // Test the undo action has been computed correctly
     undoAction->Restore();
@@ -776,44 +775,43 @@ INSTANTIATE_TEST_SUITE_P(Mesh, MeshDeletion, ::testing::ValuesIn(MeshDeletion::G
 class MeshDeletionWithInnerPolygons : public ::testing::TestWithParam<std::tuple<meshkernel::Mesh2D::DeleteMeshOptions, bool, std::vector<meshkernel::Point>, int>>
 {
 
-    static inline std::vector<meshkernel::Point> single_polygon_{
-        {-0.722886114680926, 2.22765832371444},
-        {1.50244688883463, 2.65710855246306},
-        {3.04456361934103, 1.91533088462454},
-        {3.47401384808964, 5.56565782898778},
-        {-1.42562285263321, 5.70230108358961},
-        {-0.722886114680926, 2.22765832371444},
+    static inline std::vector<meshkernel::Point> firstPolygon_{
+        {-0.5, -0.5},
+        {7.5, -0.5},
+        {7.5, 7.5},
+        {-0.5, 7.5},
+        {-0.5, -0.5},
+        {meshkernel::constants::missing::innerOuterSeparator, meshkernel::constants::missing::innerOuterSeparator},
+        {1.5, 1.5},
+        {4.5, 1.5},
+        {4.5, 4.5},
+        {1.5, 4.5},
+        {1.5, 1.5},
     };
 
-    static inline std::vector<meshkernel::Point> double_polygon_{
-        {-0.722886114680926, 2.22765832371444},
-        {1.50244688883463, 2.65710855246306},
-        {3.04456361934103, 1.91533088462454},
-        {3.47401384808964, 5.56565782898778},
-        {-1.42562285263321, 5.70230108358961},
-        {-0.722886114680926, 2.22765832371444},
-        {meshkernel::constants::missing::doubleValue, meshkernel::constants::missing::doubleValue},
-        {3.59021337251456, -1.90949318892618},
-        {6.02802927483664, -1.86121960670198},
-        {5.88320852816404, 2.09721413568238},
-        {2.55233135469427, 0.600733086732198},
-        {3.59021337251456, -1.90949318892618},
-    };
+    static inline std::vector<meshkernel::Point> secondPolygon_{
+        {-0.5, -0.5},
+        {7.5, -0.5},
+        {7.5, 7.5},
+        {-0.5, 7.5},
+        {-0.5, -0.5},
+        {meshkernel::constants::missing::innerOuterSeparator, meshkernel::constants::missing::innerOuterSeparator},
+        {1.5, 1.5},
+        {4.5, 1.5},
+        {4.5, 4.5},
+        {2.7, 4.5},
+        {2.7, 3.3},
+        {1.5, 3.3},
+        {1.5, 1.5}};
 
 public:
     [[nodiscard]] static std::vector<std::tuple<meshkernel::Mesh2D::DeleteMeshOptions, bool, std::vector<meshkernel::Point>, int>> GetData()
     {
         return {
-            {meshkernel::Mesh2D::DeleteMeshOptions::InsideAndIntersected, false, single_polygon_, 23},
-            {meshkernel::Mesh2D::DeleteMeshOptions::InsideNotIntersected, false, single_polygon_, 30},
-            {meshkernel::Mesh2D::DeleteMeshOptions::InsideAndIntersected, true, single_polygon_, 12},
-            {meshkernel::Mesh2D::DeleteMeshOptions::InsideNotIntersected, true, single_polygon_, 23},
-            {meshkernel::Mesh2D::DeleteMeshOptions::InsideAndIntersected, false, double_polygon_, 17},
-            {meshkernel::Mesh2D::DeleteMeshOptions::InsideNotIntersected, false, double_polygon_, 29},
-            {meshkernel::Mesh2D::DeleteMeshOptions::InsideAndIntersected, true, double_polygon_, 16},
-            {meshkernel::Mesh2D::DeleteMeshOptions::InsideNotIntersected, true, double_polygon_, 29}
-
-        };
+            {meshkernel::Mesh2D::DeleteMeshOptions::InsideAndIntersected, false, firstPolygon_, 9},
+            {meshkernel::Mesh2D::DeleteMeshOptions::InsideAndIntersected, true, firstPolygon_, 48},
+            {meshkernel::Mesh2D::DeleteMeshOptions::InsideAndIntersected, false, secondPolygon_, 8},
+            {meshkernel::Mesh2D::DeleteMeshOptions::InsideAndIntersected, true, secondPolygon_, 49}};
     }
 };
 
@@ -823,7 +821,7 @@ TEST_P(MeshDeletionWithInnerPolygons, expected_results)
     auto const& [deleteOption, invertSelection, polygonNodes, numNodes] = GetParam();
 
     // Setup
-    auto mesh = MakeRectangularMeshForTesting(6, 6, 1.0, meshkernel::Projection::cartesian);
+    auto mesh = MakeRectangularMeshForTesting(7, 7, 1.0, meshkernel::Projection::cartesian);
 
     const std::vector<meshkernel::Point> originalNodes(mesh->Nodes());
     const std::vector<meshkernel::Edge> originalEdges(mesh->Edges());
@@ -834,8 +832,8 @@ TEST_P(MeshDeletionWithInnerPolygons, expected_results)
     auto undoAction = mesh->DeleteMesh(polygon, deleteOption, invertSelection);
 
     // Assert
-    const auto numValidNodes = mesh->GetNumValidNodes();
-    ASSERT_EQ(numNodes, numValidNodes);
+    const auto nodes = mesh->Nodes();
+    ASSERT_EQ(numNodes, mesh->GetNumValidNodes());
 
     // Test the undo action has been computed correctly
     undoAction->Restore();


### PR DESCRIPTION
Revert intersected/non-intersected inverted deletion options (cherry picked from commit 3f8bd9c6eb851d64f0d73411879c1cc8e0946885)

Temporarily build NetCDF dependency for macOS (cherry picked from commit 010cdc50856966308f3e30142503b7551307e76f)