### PR TITLE
GRIDEDIT-1863 added github action timeout

### DIFF
--- a/.github/workflows/build-and-test-workflow.yml
+++ b/.github/workflows/build-and-test-workflow.yml
@@ -101,6 +101,7 @@ jobs:
       #       Works if runner.os == 'Linux' or runner.os == 'macOS'
       #       if runner.os == 'Windows',  /inputs.build_type needs to be inserted before /tests
       - name: Test
+        timeout-minutes: 2 # Set timeout to 90 minutes
         run: |
           echo -e "\n***************   MeshKernel Tests   ***************\n"
           ${{ steps.paths.outputs.build_dir }}/libs/MeshKernel/tests/MeshKernelUnitTests

--- a/.github/workflows/build-and-test-workflow.yml
+++ b/.github/workflows/build-and-test-workflow.yml
@@ -101,7 +101,7 @@ jobs:
       #       Works if runner.os == 'Linux' or runner.os == 'macOS'
       #       if runner.os == 'Windows',  /inputs.build_type needs to be inserted before /tests
       - name: Test
-        timeout-minutes: 2 # Set timeout to 90 minutes
+        timeout-minutes: 10 # Set timeout to 10 minutes
         run: |
           echo -e "\n***************   MeshKernel Tests   ***************\n"
           ${{ steps.paths.outputs.build_dir }}/libs/MeshKernel/tests/MeshKernelUnitTests


### PR DESCRIPTION
 Added a timeout for the testing. 

Tried this with a 2 minute timeout and that works. Current main is hanging in the tests due to GRIDEDIT-1864
![image](https://github.com/user-attachments/assets/3e99ebb6-cc5f-456f-9877-a78586d9b17b)

Please be aware that some of the checks are currently failing:
![image](https://github.com/user-attachments/assets/9657230d-c252-475d-8ab5-50689e85eaa7)
- MacOS-14 is due to a hanging test on MacOS and the changes in this PR will make the config stop running the tests after 10 minutes.
- Sonarcloud code analysis was already failing on main.