### PR TITLE
GRIDEDIT-1911 Fixed bug when computing contacts from points 

### DIFF
--- a/libs/MeshKernel/src/Contacts.cpp
+++ b/libs/MeshKernel/src/Contacts.cpp
@@ -352,6 +352,11 @@ void Contacts::ComputeContactsWithPoints(const std::vector<bool>& oneDNodeMask,
                              m_mesh1d.GetNumNodes());
     }
 
+    if (m_mesh1d.GetNumNodes() == 0)
+    {
+        return;
+    }
+
     // perform mesh1d administration (m_nodesRTree will also be build if necessary)
     m_mesh1d.AdministrateNodesEdges();
 
@@ -367,12 +372,6 @@ void Contacts::ComputeContactsWithPoints(const std::vector<bool>& oneDNodeMask,
     for (UInt i = 0; i < points.size(); ++i)
     {
 
-        // Account for 1d node mask if present
-        if (!oneDNodeMask.empty() && !oneDNodeMask[i])
-        {
-            continue;
-        }
-
         // point not in the mesh
         if (pointsFaceIndices[i] == constants::missing::uintValue)
         {
@@ -382,15 +381,13 @@ void Contacts::ComputeContactsWithPoints(const std::vector<bool>& oneDNodeMask,
         // get the closest 1d node
         rtree.SearchNearestPoint(points[i]);
 
-        // if nothing found continue
-        if (rtree.GetQueryResultSize() == 0)
-        {
-            continue;
-        }
-
         // form the 1d-2d contact
-        m_mesh1dIndices.emplace_back(rtree.GetQueryResult(0));
-        m_mesh2dIndices.emplace_back(pointsFaceIndices[i]);
+        // Account for 1d node mask
+        if (rtree.GetQueryResultSize() > 0 && rtree.GetQueryResult(0) != constants::missing::uintValue && oneDNodeMask[rtree.GetQueryResult(0)])
+        {
+            m_mesh1dIndices.emplace_back(rtree.GetQueryResult(0));
+            m_mesh2dIndices.emplace_back(pointsFaceIndices[i]);
+        }
     }
 }
 

--- a/libs/MeshKernel/tests/src/ContactsTests.cpp
+++ b/libs/MeshKernel/tests/src/ContactsTests.cpp
@@ -36,6 +36,7 @@
 #include <MeshKernel/Mesh1D.hpp>
 #include <MeshKernel/Mesh2D.hpp>
 #include <MeshKernel/Polygons.hpp>
+#include <MeshKernel/Utilities/Utilities.hpp>
 #include <gmock/gmock-matchers.h>
 
 using namespace meshkernel;
@@ -523,9 +524,102 @@ TEST_F(ContactsTests, AllMixedBooleanNodeMask)
     ASSERT_EQ(m1dIndices.size(), 2);
     ASSERT_EQ(m2dIndices.size(), 2);
 
-    EXPECT_EQ(m1dIndices[0], 1);
+    EXPECT_EQ(m1dIndices[0], 3);
     EXPECT_EQ(m1dIndices[1], 6);
 
-    EXPECT_EQ(m2dIndices[0], 2);
+    EXPECT_EQ(m2dIndices[0], 42);
     EXPECT_EQ(m2dIndices[1], 75);
+}
+
+TEST(Contacts, GenerateContactsMorePointsThanOneDMesh)
+{
+
+    // This test checks that the contacts generated are correct when the
+    // number of points is greater than the number of nodes in the oned mesh
+
+    // Create 1d mesh
+    std::vector<Point> nodes{{-9.0, -3.0},
+                             {-8.18181818, -2.36363636},
+                             {-7.36363636, -1.72727273},
+                             {-6.54545455, -1.09090909},
+                             {-5.72727273, -0.45454545},
+                             {-4.90909091, 0.18181818},
+                             {-4.09090909, 0.81818182},
+                             {-3.27272727, 1.45454545},
+                             {-2.45454545, 2.09090909},
+                             {-1.63636364, 2.72727273},
+                             {-0.81818182, 3.36363636},
+                             {0.0, 4.0},
+                             {1.0, 4.11111111},
+                             {2.0, 4.22222222},
+                             {3.0, 4.33333333},
+                             {4.0, 4.44444444},
+                             {5.0, 4.55555556},
+                             {6.0, 4.66666667},
+                             {7.0, 4.77777778},
+                             {8.0, 4.88888889},
+                             {9.0, 5.0}};
+    std::vector<Edge> edges{nodes.size() - 1};
+
+    for (size_t i = 0; i < edges.size(); ++i)
+    {
+        edges[i].first = i;
+        edges[i].second = i + 1;
+    }
+
+    const auto mesh1d = std::make_shared<Mesh1D>(edges, nodes, Projection::cartesian);
+
+    // Create 2d mesh
+    const auto mesh2d = MakeRectangularMeshForTesting(32, 8, 0.5, Projection::cartesian, {-8.0, 2.5});
+
+    // Create contacts
+    std::vector<bool> onedNodeMask(nodes.size(), true);
+    Contacts contacts(*mesh1d, *mesh2d);
+
+    std::vector<Point> points{{-1.75, 2.75},
+                              {-1.25, 2.75},
+                              {-1.25, 3.25},
+                              {-0.75, 3.25},
+                              {-0.75, 3.75},
+                              {-0.25, 3.75},
+                              {0.25, 3.75},
+                              {-0.25, 4.25},
+                              {0.25, 4.25},
+                              {0.75, 4.25},
+                              {1.25, 4.25},
+                              {1.75, 4.25},
+                              {2.25, 4.25},
+                              {2.75, 4.25},
+                              {3.25, 4.25},
+                              {3.75, 4.25},
+                              {4.25, 4.25},
+                              {4.25, 4.75},
+                              {4.75, 4.75},
+                              {5.25, 4.75},
+                              {5.75, 4.75},
+                              {6.25, 4.75},
+                              {6.75, 4.75},
+                              {7.25, 4.75}};
+
+    // Execute
+    contacts.ComputeContactsWithPoints(onedNodeMask, points);
+
+    std::vector<meshkernel::UInt> expected1dIndices{9, 9, 10, 10, 10, 11, 11, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 15, 16, 16, 17, 17, 18, 18};
+    std::vector<meshkernel::UInt> expected2dIndices{84, 91, 92, 99, 100, 107, 114, 108, 115, 122, 129, 136, 143, 150, 157, 164, 171, 172, 179, 186, 193, 200, 207, 214};
+
+    auto m1dIndices = contacts.Mesh1dIndices();
+    auto m2dIndices = contacts.Mesh2dIndices();
+
+    ASSERT_EQ(m1dIndices.size(), expected1dIndices.size());
+    ASSERT_EQ(m2dIndices.size(), expected2dIndices.size());
+
+    for (size_t i = 0; i < m1dIndices.size(); ++i)
+    {
+        EXPECT_EQ(expected1dIndices[i], m1dIndices[i]);
+    }
+
+    for (size_t i = 0; i < m2dIndices.size(); ++i)
+    {
+        EXPECT_EQ(expected2dIndices[i], m2dIndices[i]);
+    }
 }


### PR DESCRIPTION
when the number of points is different from the number of nodes in the one d mesh.